### PR TITLE
"sed -b" isn't supported on OSX

### DIFF
--- a/scripts/hash_version.sh
+++ b/scripts/hash_version.sh
@@ -9,8 +9,9 @@ fi
 GIT_HASH=`git status > /dev/null 2>&1 && git rev-parse HEAD || echo NO_GIT_COMMIT_HASH_DEFINED`;
 
 rm -f ver
-sed -b "s/NO_GIT_COMMIT_HASH_DEFINED/$GIT_HASH$1/" renderdoc/data/resource.h > ver && mv ver renderdoc/data/resource.h
-sed -b "s/NO_GIT_COMMIT_HASH_DEFINED/$GIT_HASH$1/" qrenderdoc/Resources/resource.h > ver && mv ver qrenderdoc/Resources/resource.h
-sed -b "s/NO_GIT_COMMIT_HASH_DEFINED/$GIT_HASH$1/" renderdoccmd/resource.h > ver && mv ver renderdoccmd/resource.h
-sed -b "s/NO_GIT_COMMIT_HASH_DEFINED/$GIT_HASH$1/" renderdocui/Properties/AssemblyInfo.cs > ver && mv ver renderdocui/Properties/AssemblyInfo.cs
+sed "s/NO_GIT_COMMIT_HASH_DEFINED/$GIT_HASH$1/" renderdoc/data/resource.h > ver && mv ver renderdoc/data/resource.h
+sed "s/NO_GIT_COMMIT_HASH_DEFINED/$GIT_HASH$1/" qrenderdoc/Resources/resource.h > ver && mv ver qrenderdoc/Resources/resource.h
+#iconv -f utf-16 -t utf-8 qrenderdoc/Resources/resource.h | sed "s/NO_GIT_COMMIT_HASH_DEFINED/$GIT_HASH$1/" | iconv -f utf-8 -t utf-16 > ver && mv ver qrenderdoc/Resources/resource.h
+iconv -f utf-16 -t utf-8 renderdoccmd/resource.h | sed "s/NO_GIT_COMMIT_HASH_DEFINED/$GIT_HASH$1/" | iconv -f utf-8 -t utf-16 > ver && mv ver renderdoccmd/resource.h
+sed "s/NO_GIT_COMMIT_HASH_DEFINED/$GIT_HASH$1/" renderdocui/Properties/AssemblyInfo.cs > ver && mv ver renderdocui/Properties/AssemblyInfo.cs
 rm -f ver


### PR DESCRIPTION
Use iconv to convert utf16 files to utf8
sed the utf8 file
Use iconv to convert back to utf16