### PR TITLE
Apple GL replay asynchronously runs Apple APIs on the main thread

### DIFF
--- a/renderdoc/driver/gl/cgl_platform.mm
+++ b/renderdoc/driver/gl/cgl_platform.mm
@@ -1,26 +1,359 @@
 #import <Cocoa/Cocoa.h>
+#include <libkern/OSAtomic.h>
+#include <pthread.h>
 
-extern "C" void NSGL_LogText(const char *text);
+#define RD_THREAD_RANDOM_SLEEP (0)
+#define RD_USE_CONTEXT_LOCK_COUNTS (0)
+
+void NSGL_LogText(const char *text);
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
-extern "C" int NSGL_getLayerWidth(void *layer)
-{
-  CALayer *caLayer = (CALayer *)layer;
-  assert([caLayer isKindOfClass:[CALayer class]]);
+static pthread_key_t s_currentContextTLSkey;
 
-  return caLayer.bounds.size.width;
+static int s_WindowCountMax;
+static int s_WindowCount;
+static NSLock *s_WindowIndexesArrayLock;
+static NSView **s_WindowIndexes;
+static int *s_WindowWidths;
+static int *s_WindowHeights;
+
+static int s_ContextCountMax;
+static int s_ContextCount;
+static NSLock *s_ContextIndexesArrayLock;
+static NSOpenGLContext **s_ContextIndexes;
+static NSMutableArray<NSRecursiveLock *> *s_ContextLocks;
+#if RD_USE_CONTEXT_LOCK_COUNTS
+static int32_t *s_ContextLocksCount;
+#endif    // #if RD_USE_CONTEXT_LOCK_COUNTS
+
+static void scheduleContextSetView(int contextIndex, NSView *view);
+static void scheduleContextUpdate(int contextIndex);
+
+static void RandomSleep()
+{
+#if RD_THREAD_RANDOM_SLEEP
+  usleep(rand() % 2000);
+#endif    // #if RD_THREAD_RANDOM_SLEEP
 }
 
-extern "C" int NSGL_getLayerHeight(void *layer)
+static NSOpenGLContext *GetNSOpenGLContext(void *context)
 {
-  CALayer *caLayer = (CALayer *)layer;
-  assert([caLayer isKindOfClass:[CALayer class]]);
-
-  return caLayer.bounds.size.height;
+  NSOpenGLContext *nsglContext = (NSOpenGLContext *)context;
+  assert([nsglContext isKindOfClass:[NSOpenGLContext class]]);
+  return nsglContext;
 }
 
-extern "C" void *NSGL_createContext(void *view, void *shareContext)
+static NSView *GetNSView(void *view)
+{
+  NSView *nsView = (NSView *)view;
+  assert([nsView isKindOfClass:[NSView class]]);
+  return nsView;
+}
+
+static void IncrementContextLockCount(int contextIndex)
+{
+#if RD_USE_CONTEXT_LOCK_COUNTS
+  OSAtomicIncrement32Barrier(s_ContextLocksCount + contextIndex);
+#endif    //#if RD_USE_CONTEXT_LOCK_COUNTS
+}
+
+static void DecrementContextLockCount(int contextIndex)
+{
+#if RD_USE_CONTEXT_LOCK_COUNTS
+  OSAtomicDecrement32Barrier(s_ContextLocksCount + contextIndex);
+#endif    //#if RD_USE_CONTEXT_LOCK_COUNTS
+}
+
+static void LockContext(int contextIndex)
+{
+  [s_ContextLocks[contextIndex] lock];
+  IncrementContextLockCount(contextIndex);
+}
+
+static bool TryLockContext(int contextIndex)
+{
+  if([s_ContextLocks[contextIndex] tryLock])
+  {
+    IncrementContextLockCount(contextIndex);
+    return true;
+  }
+  return false;
+}
+
+static void UnLockContext(int contextIndex)
+{
+  DecrementContextLockCount(contextIndex);
+  [s_ContextLocks[contextIndex] unlock];
+}
+
+static void LockWindowIndexesArray()
+{
+  [s_WindowIndexesArrayLock lock];
+}
+
+static void UnLockWindowIndexesArray()
+{
+  [s_WindowIndexesArrayLock unlock];
+}
+
+static int getWindowIndex(NSView *nsView)
+{
+  LockWindowIndexesArray();
+  int firstFreeIndex = s_WindowCount;
+  for(int i = 0; i < s_WindowCount; ++i)
+  {
+    if(s_WindowIndexes[i] == nsView)
+    {
+      UnLockWindowIndexesArray();
+      return i;
+    }
+    if((s_WindowIndexes[i] == nil) && (i < firstFreeIndex))
+    {
+      firstFreeIndex = i;
+    }
+  }
+  const int index = firstFreeIndex;
+  if(index >= s_WindowCountMax)
+  {
+    const int oldCapacity = s_WindowCountMax;
+    s_WindowCountMax = s_WindowCount * 2;
+    s_WindowIndexes = (NSView **)realloc(s_WindowIndexes, s_WindowCountMax * sizeof(NSView *));
+    s_WindowWidths = (int *)realloc(s_WindowWidths, s_WindowCountMax * sizeof(int));
+    s_WindowHeights = (int *)realloc(s_WindowHeights, s_WindowCountMax * sizeof(int));
+    for(int i = oldCapacity; i < s_WindowCountMax; ++i)
+    {
+      s_WindowIndexes[i] = nil;
+    }
+  }
+  assert(index >= 0 && index < s_WindowCountMax);
+  s_WindowIndexes[index] = nsView;
+  s_WindowWidths[index] = 0;
+  s_WindowHeights[index] = 0;
+  if(index == s_WindowCount)
+    ++s_WindowCount;
+  UnLockWindowIndexesArray();
+  return index;
+}
+
+static void LockContextIndexesArray()
+{
+  [s_ContextIndexesArrayLock lock];
+}
+
+static void UnLockContextIndexesArray()
+{
+  [s_ContextIndexesArrayLock unlock];
+}
+
+static void SetCurrentContextTLS(int contextIndex)
+{
+  const intptr_t key = contextIndex;
+  pthread_setspecific(s_currentContextTLSkey, (void *)key);
+}
+
+static int GetCurrentContextTLS()
+{
+  const intptr_t value = (intptr_t)pthread_getspecific(s_currentContextTLSkey);
+  return value;
+}
+
+static int getContextIndex(NSOpenGLContext *nsglContext)
+{
+  LockContextIndexesArray();
+  int firstFreeIndex = s_ContextCount;
+  for(int i = 0; i < s_ContextCount; ++i)
+  {
+    if(s_ContextIndexes[i] == nsglContext)
+    {
+      UnLockContextIndexesArray();
+      return i;
+    }
+    if((s_ContextIndexes[i] == nil) && (i < firstFreeIndex))
+    {
+      firstFreeIndex = i;
+    }
+  }
+  const int index = firstFreeIndex;
+  if(index >= s_ContextCountMax)
+  {
+    const int oldCapacity = s_ContextCountMax;
+    s_ContextCountMax = s_ContextCount * 2;
+    s_ContextIndexes =
+        (NSOpenGLContext **)realloc(s_ContextIndexes, s_ContextCountMax * sizeof(NSOpenGLContext *));
+#if RD_USE_CONTEXT_LOCK_COUNTS
+    s_ContextLocksCount =
+        (int32_t *)realloc(s_ContextLocksCount, s_ContextCountMax * sizeof(int32_t));
+#endif    // #if RD_USE_CONTEXT_LOCK_COUNTS
+    for(int i = oldCapacity; i < s_ContextCountMax; ++i)
+    {
+      s_ContextLocks[i] = [NSRecursiveLock alloc];
+      s_ContextIndexes[i] = nil;
+    }
+  }
+  assert(index >= 0 && index < s_ContextCountMax);
+  s_ContextIndexes[index] = nsglContext;
+#if RD_USE_CONTEXT_LOCK_COUNTS
+  s_ContextLocksCount[index] = 0;
+#endif    // #if RD_USE_CONTEXT_LOCK_COUNTS
+  assert(s_ContextLocks[index]);
+  [s_ContextLocks[index] init];
+  if(index == s_ContextCount)
+    ++s_ContextCount;
+  UnLockContextIndexesArray();
+  return index;
+}
+
+static NSOpenGLContext *getLockedContext(int contextIndex)
+{
+  LockContextIndexesArray();
+  assert(contextIndex >= 0 && contextIndex < s_ContextCount);
+  NSOpenGLContext *context = s_ContextIndexes[contextIndex];
+  if(context && !TryLockContext(contextIndex))
+  {
+    context = nil;
+  }
+  UnLockContextIndexesArray();
+  return context;
+}
+
+static void viewSetWantBestResolutionMT(NSView *view)
+{
+  [view setWantsBestResolutionOpenGLSurface:true];
+}
+
+static void viewGetWindowSizeMT(int windowIndex)
+{
+  RandomSleep();
+  LockWindowIndexesArray();
+  assert(windowIndex >= 0 && windowIndex < s_WindowCount);
+  NSView *view = s_WindowIndexes[windowIndex];
+  if(view)
+  {
+    const NSRect contentRect = [view frame];
+    CGSize viewSize = [view convertSizeToBacking:contentRect.size];
+
+    s_WindowWidths[windowIndex] = viewSize.width;
+    s_WindowHeights[windowIndex] = viewSize.height;
+  }
+  UnLockWindowIndexesArray();
+}
+
+static void contextUpdateMT(int contextIndex)
+{
+  RandomSleep();
+  NSOpenGLContext *lockedContext = getLockedContext(contextIndex);
+  if(lockedContext)
+  {
+    [lockedContext update];
+    UnLockContext(contextIndex);
+  }
+  else
+  {
+    scheduleContextUpdate(contextIndex);
+  }
+}
+
+static void contextSetViewMT(int contextIndex, NSView *view)
+{
+  RandomSleep();
+  NSOpenGLContext *lockedContext = getLockedContext(contextIndex);
+  if(lockedContext)
+  {
+    [lockedContext setView:view];
+    [lockedContext update];
+    UnLockContext(contextIndex);
+  }
+  else
+  {
+    scheduleContextSetView(contextIndex, view);
+  }
+}
+
+static void scheduleContextSetView(int contextIndex, NSView *view)
+{
+  RandomSleep();
+  dispatch_async(dispatch_get_main_queue(), ^(void) {
+    contextSetViewMT(contextIndex, view);
+  });
+}
+
+static void scheduleContextUpdate(int contextIndex)
+{
+  RandomSleep();
+  dispatch_async(dispatch_get_main_queue(), ^(void) {
+    contextUpdateMT(contextIndex);
+  });
+}
+
+static void scheduleViewSetWantBestResolution(NSView *view)
+{
+  dispatch_async(dispatch_get_main_queue(), ^(void) {
+    viewSetWantBestResolutionMT(view);
+  });
+}
+
+static void scheduleViewGetWindowSizeMT(int windowIndex)
+{
+  dispatch_async(dispatch_get_main_queue(), ^(void) {
+    viewGetWindowSizeMT(windowIndex);
+  });
+}
+
+void getAppleWindowGetSize(void *view, int &width, int &height)
+{
+  if(!view)
+  {
+    width = 0;
+    height = 0;
+    return;
+  }
+  NSView *nsView = GetNSView(view);
+  const int windowIndex = getWindowIndex(nsView);
+  width = s_WindowWidths[windowIndex];
+  height = s_WindowHeights[windowIndex];
+  scheduleViewGetWindowSizeMT(windowIndex);
+}
+
+void stopTrackingWindowSize(void *view)
+{
+  if(!view)
+    return;
+  NSView *nsView = GetNSView(view);
+  const int windowIndex = getWindowIndex(nsView);
+  LockWindowIndexesArray();
+  s_WindowIndexes[windowIndex] = nil;
+  s_WindowWidths[windowIndex] = 0;
+  s_WindowHeights[windowIndex] = 0;
+  UnLockWindowIndexesArray();
+}
+
+void NSGL_init()
+{
+  const int result = pthread_key_create(&s_currentContextTLSkey, nil);
+  assert(result == 0);
+  SetCurrentContextTLS(-1);
+
+  s_WindowIndexesArrayLock = [[NSLock alloc] init];
+  s_WindowCountMax = 8;
+  s_WindowIndexes = (NSView **)calloc(s_WindowCountMax, sizeof(NSView *));
+  s_WindowWidths = (int *)calloc(s_WindowCountMax, sizeof(int));
+  s_WindowHeights = (int *)calloc(s_WindowCountMax, sizeof(int));
+  s_WindowCount = 0;
+
+  s_ContextIndexesArrayLock = [[NSLock alloc] init];
+  s_ContextCountMax = 8;
+  s_ContextIndexes = (NSOpenGLContext **)calloc(s_ContextCountMax, sizeof(NSView *));
+#if RD_USE_CONTEXT_LOCK_COUNTS
+  s_ContextLocksCount = (int32_t *)calloc(s_ContextCountMax, sizeof(int32_t));
+#endif    // #if RD_USE_CONTEXT_LOCK_COUNTS
+  s_ContextLocks = [NSMutableArray<NSRecursiveLock *> arrayWithCapacity:s_ContextCountMax];
+  for(int i = 0; i < s_ContextCountMax; ++i)
+    s_ContextLocks[i] = [NSRecursiveLock alloc];
+  s_ContextCount = 0;
+}
+
+void *NSGL_createContext(void *view, void *shareContext)
 {
   NSView *nsView = (NSView *)view;
   assert(nsView == nil || [nsView isKindOfClass:[NSView class]]);
@@ -29,17 +362,21 @@ extern "C" void *NSGL_createContext(void *view, void *shareContext)
   assert(share == nil || [share isKindOfClass:[NSOpenGLContext class]]);
 
   NSOpenGLPixelFormatAttribute attr[] = {
-      NSOpenGLPFANoRecovery,
-      NSOpenGLPFADoubleBuffer,
       NSOpenGLPFAAccelerated,
-      NSOpenGLPFAAllowOfflineRenderers,
-
+      NSOpenGLPFAClosestPolicy,
       NSOpenGLPFAOpenGLProfile,
       NSOpenGLProfileVersion4_1Core,
-
       NSOpenGLPFAColorSize,
-      32,
-
+      24,
+      NSOpenGLPFAAlphaSize,
+      8,
+      NSOpenGLPFADepthSize,
+      24,
+      NSOpenGLPFAStencilSize,
+      8,
+      NSOpenGLPFADoubleBuffer,
+      NSOpenGLPFASampleBuffers,
+      0,
       0,
   };
 
@@ -63,46 +400,62 @@ extern "C" void *NSGL_createContext(void *view, void *shareContext)
   GLint aboveWindow = 1;
   [context setValues:&aboveWindow forParameter:NSOpenGLCPSurfaceOrder];
 
-  [context setView:nsView];
-  [context update];
+  scheduleViewSetWantBestResolution(nsView);
+
+  NSOpenGLContext *nsglContext = GetNSOpenGLContext(context);
+  const int contextIndex = getContextIndex(nsglContext);
+  scheduleContextSetView(contextIndex, nsView);
 
   return context;
 }
 
-extern "C" void NSGL_makeCurrentContext(void *context)
+void NSGL_makeCurrentContext(void *context)
 {
-  NSOpenGLContext *nsglContext = (NSOpenGLContext *)context;
-  assert([nsglContext isKindOfClass:[NSOpenGLContext class]]);
+  const int currentThreadContextIndex = GetCurrentContextTLS();
+  if(currentThreadContextIndex >= 0)
+    UnLockContext(currentThreadContextIndex);
 
+  NSOpenGLContext *nsglContext = GetNSOpenGLContext(context);
+  const int contextIndex = getContextIndex(nsglContext);
+  SetCurrentContextTLS(contextIndex);
+  LockContext(contextIndex);
   [nsglContext makeCurrentContext];
+  scheduleContextUpdate(contextIndex);
 }
 
-extern "C" void NSGL_update(void *context)
+void NSGL_update(void *context)
 {
-  NSOpenGLContext *nsglContext = (NSOpenGLContext *)context;
-  assert([nsglContext isKindOfClass:[NSOpenGLContext class]]);
-
-  [nsglContext update];
+  NSOpenGLContext *nsglContext = GetNSOpenGLContext(context);
+  const int contextIndex = getContextIndex(nsglContext);
+  scheduleContextUpdate(contextIndex);
 }
 
-extern "C" void NSGL_flushBuffer(void *context)
+void NSGL_flushBuffer(void *context)
 {
-  NSOpenGLContext *nsglContext = (NSOpenGLContext *)context;
-  assert([nsglContext isKindOfClass:[NSOpenGLContext class]]);
-
+  NSOpenGLContext *nsglContext = GetNSOpenGLContext(context);
+  const int contextIndex = getContextIndex(nsglContext);
+  LockContext(contextIndex);
   [nsglContext flushBuffer];
+  UnLockContext(contextIndex);
 }
 
-extern "C" void NSGL_destroyContext(void *context)
+void NSGL_destroyContext(void *context)
 {
   @autoreleasepool
   {
-    NSOpenGLContext *nsglContext = (NSOpenGLContext *)context;
-    assert([nsglContext isKindOfClass:[NSOpenGLContext class]]);
+    NSOpenGLContext *nsglContext = GetNSOpenGLContext(context);
+    const int contextIndex = getContextIndex(nsglContext);
+    {
+      LockContext(contextIndex);
+      [nsglContext makeCurrentContext];
+      [nsglContext clearDrawable];
+      [nsglContext update];
+      [nsglContext release];
+      UnLockContext(contextIndex);
+    }
 
-    [nsglContext makeCurrentContext];
-    [nsglContext clearDrawable];
-    [nsglContext update];
-    [nsglContext release];
+    LockContextIndexesArray();
+    s_ContextIndexes[contextIndex] = nil;
+    UnLockContextIndexesArray();
   }
 }

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -198,8 +198,6 @@ struct GLWindowingData
     ctx = NULL;
     wnd = NULL;
     pix = NULL;
-
-    layer = NULL;
   }
 
   union
@@ -210,8 +208,6 @@ struct GLWindowingData
 
   void *wnd;    // during capture, this is the CGL window ID. During replay, it's the NSView
   CGLPixelFormatObj pix;
-
-  void *layer;    // during replay only, this is the CALayer
 };
 
 #define DECL_HOOK_EXPORT(function)                                                                    \


### PR DESCRIPTION
## Description

These operations now run on the main thread and not on the Replay thread
* Updating the NSOpenGLContext
* Setting the NSView property on the NSOpenGLContext
* Getting the window size from the NSView

The specific methods are:
* NSOpenGLContext setView
* NSOpenGLContext update
* NSView frame
* NSView convertSizeToBacking
* NSView setWantsBestResolutionOpenGLSurface


These methods are asynchronously dispatched to the main thread using the Apple NSApplication main thread dispatch queue i.e.

dispatch_async(dispatch_get_main_queue(), <method>)

The threading synchronization intent is:
* the Replay never blocks waiting for a deferred main thread API to complete
* mutex locks are used to protect containers shared between the main and Replay threads
* the main thread uses a TryLock approach when wanting to acquire the context lock. If the context lock is held by the Replay thread then the main thread reschedules the requested context operation i.e.

```
if (TryToGetContectLock(context))
{
  [context update];
}
else
{
  scheduleContextUpdate(context);
}
```

* When scheduling requests to the main thread the NSOpenGLContext and NSView objects are referred to by an index into an array and not by pointer value.

Two debugging modes are disabled by default
* RD_THREAD_RANDOM_SLEEP
* RD_USE_CONTEXT_LOCK_COUNTS

Enabling RD_THREAD_RANDOM_SLEEP performs a sleep of random times on both the Replay and main thread when calling the different context and view methods.

Enabling RD_USE_CONTEXT_LOCK_COUNTS tracks the lock count on the context objects in the "s_ContextLocksCount" container.

By default non-recursive mutex locks (NSLock) are used where possible i.e. to make the shared containers thread-safe.

The context lock uses a recursive mutex lock (NSRecursiveLock).

The low-level context locking is handled in NSGL_makeCurrentContext which is called from CGLPlatform::MakeContextCurrent which in turn is called from GLReplay::MakeCurrentReplayContext.
The currently locked context is tracked in TLS storage and the currently locked context is unlocked before locking the new context and then setting the current context TLS value.

## Testing

qrenderdoc capture replay has been tested on Apple Mac using various capture files: GL Simple Triangle from the RenderDoc tests, Unity runtime application built from the Unity Learn Kart project, Unity Editor using the Unity Kart project, the "ogl-samples " project which was compiled locally and approximately 30 of the GL test applications were captured and replayed in qrenderdoc.

Manual testing was performed with the Mesh Viewer and Texture Viewer windows open at the same and selecting different drawcall events and then inspecting the Mesh and Texture windows. The primary focus was on the Texture window, checking the context display and the thumbnails.

Automated testing was performed using a simple python test script
```
import random

miniQtHelper = pyrenderdoc.Extensions().GetMiniQtHelper()

firstEID = pyrenderdoc.GetFirstDrawcall().eventId
lastEID = pyrenderdoc.GetLastDrawcall().eventId
countRandomEvents = 1000
exclude = []

for x in range(countRandomEvents):
    dice = random.randint(0,100)
    if (dice < 20):
        miniQtHelper.CloseToplevelWidget(pyrenderdoc.GetMeshPreview().Widget())
    elif (dice < 40):
        miniQtHelper.CloseToplevelWidget(pyrenderdoc.GetTextureViewer().Widget())

    dice = random.randint(0,100)
    if (dice < 10):
        pyrenderdoc.ShowMeshPreview()
        pyrenderdoc.ShowTextureViewer()
    elif (dice < 40):
        pyrenderdoc.ShowMeshPreview()
    elif (dice < 70):
        pyrenderdoc.ShowTextureViewer()

    pyrenderdoc.ShowPipelineViewer()
    pipelineWidget = pyrenderdoc.GetPipelineViewer().Widget()

    meshWidget = pyrenderdoc.GetMeshPreview().Widget()
    textureWidget = pyrenderdoc.GetTextureViewer().Widget()
    dice = random.randint(0,100)
    if (dice < 33):
        pyrenderdoc.AddDockWindow(meshWidget, qrenderdoc.DockReference.TopOf, pipelineWidget, 0.25)
    elif (dice < 66):
        pyrenderdoc.AddDockWindow(textureWidget, qrenderdoc.DockReference.BottomOf, pipelineWidget, 0.25)

    eid = random.randint(firstEID, lastEID)
    pyrenderdoc.SetEventID(exclude, eid, eid, True)
    print("UI: %d/%d EID:%d" % (x+1, countRandomEvents, pyrenderdoc.CurEvent()))
```

During the testing process, the RD_THREAD_RANDOM_SLEEP  and RD_USE_CONTEXT_LOCK_COUNTS  debugging helper modes were enabled. With this final version of the code, no crashes or deadlocks have been found (previous versions of the code or if the thread safety and locking are removed in the current code will crash when running the automated test script).

Here is a short video showing the automated stress test python script: [https://www.icloud.com/iclouddrive/00qNgWkbxPNJun4cesW-275ew#renderdoc-gl-stress-test](url)
