### PR TITLE
Adding wrapped MTLLibrary and MTLFunction

### DIFF
--- a/renderdoc/driver/metal/CMakeLists.txt
+++ b/renderdoc/driver/metal/CMakeLists.txt
@@ -11,6 +11,7 @@ set(sources
     metal_types_bridge.mm
     metal_types_bridge.h
     metal_types.h
+    metal_common.h
     official/metal-cpp.h
     official/metal-cpp.cpp)
 

--- a/renderdoc/driver/metal/CMakeLists.txt
+++ b/renderdoc/driver/metal/CMakeLists.txt
@@ -12,6 +12,12 @@ set(sources
     metal_types_bridge.mm
     metal_types_bridge.h
     metal_types.h
+    metal_library.cpp
+    metal_library.h
+    metal_library_bridge.mm
+    metal_function.cpp
+    metal_function.h
+    metal_function_bridge.mm
     metal_common.h
     official/metal-cpp.h
     official/metal-cpp.cpp)

--- a/renderdoc/driver/metal/CMakeLists.txt
+++ b/renderdoc/driver/metal/CMakeLists.txt
@@ -7,6 +7,7 @@ set(sources
     metal_device.cpp
     metal_device.h
     metal_device_bridge.mm
+    metal_resources.cpp
     metal_resources.h
     metal_types_bridge.mm
     metal_types_bridge.h

--- a/renderdoc/driver/metal/metal_common.h
+++ b/renderdoc/driver/metal/metal_common.h
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "api/replay/rdcstr.h"
+#include "common/common.h"
+#include "official/metal-cpp.h"
+#include "metal_resources.h"
+#include "metal_types.h"
+
+#ifdef __OBJC__
+#define METAL_NOT_HOOKED()                                                             \
+  do                                                                                   \
+  {                                                                                    \
+    RDCWARN("Metal %s %s not hooked", class_getName([self class]), sel_getName(_cmd)); \
+  } while((void)0, 0)
+#endif

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -25,7 +25,7 @@
 #include "metal_device.h"
 
 WrappedMTLDevice::WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId)
-    : WrappedMTLObject(realMTLDevice, objId, this)
+    : WrappedMTLObject(realMTLDevice, objId, this, GetStateRef())
 {
   wrappedObjC = AllocateObjCWrapper(this);
   m_WrappedMTLDevice = this;

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include "metal_resources.h"
+#include "metal_common.h"
 
 class WrappedMTLDevice : public WrappedMTLObject
 {
@@ -33,5 +33,12 @@ public:
   ~WrappedMTLDevice() {}
   static MTL::Device *MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice);
 
+  CaptureState &GetStateRef() { return m_State; }
+  enum
+  {
+    TypeEnum = eResDevice
+  };
+
 private:
+  CaptureState m_State;
 };

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -41,12 +41,14 @@
   return id<MTLDevice>(real);
 }
 
+// Use the real MTLDevice to find methods from messages
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
 {
   id fwd = self.real;
   return [fwd methodSignatureForSelector:aSelector];
 }
 
+// Forward any unknown messages to the real MTLDevice
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
   SEL aSelector = [invocation selector];
@@ -179,20 +181,20 @@
 
 - (nullable id<MTLCommandQueue>)newCommandQueue
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newCommandQueue];
 }
 
 - (nullable id<MTLCommandQueue>)newCommandQueueWithMaxCommandBufferCount:(NSUInteger)maxCommandBufferCount
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newCommandQueueWithMaxCommandBufferCount:maxCommandBufferCount];
 }
 
 - (MTLSizeAndAlign)heapTextureSizeAndAlignWithDescriptor:(MTLTextureDescriptor *)desc
     API_AVAILABLE(macos(10.13), ios(10.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real heapTextureSizeAndAlignWithDescriptor:desc];
 }
 
@@ -200,20 +202,20 @@
                                             options:(MTLResourceOptions)options
     API_AVAILABLE(macos(10.13), ios(10.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real heapBufferSizeAndAlignWithLength:length options:options];
 }
 
 - (nullable id<MTLHeap>)newHeapWithDescriptor:(MTLHeapDescriptor *)descriptor
     API_AVAILABLE(macos(10.13), ios(10.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newHeapWithDescriptor:descriptor];
 }
 
 - (nullable id<MTLBuffer>)newBufferWithLength:(NSUInteger)length options:(MTLResourceOptions)options
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newBufferWithLength:length options:options];
 }
 
@@ -221,7 +223,7 @@
                                       length:(NSUInteger)length
                                      options:(MTLResourceOptions)options
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newBufferWithBytes:pointer length:length options:options];
 }
 
@@ -231,7 +233,7 @@
                                        deallocator:(void (^__nullable)(void *pointer,
                                                                        NSUInteger length))deallocator
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newBufferWithBytesNoCopy:pointer
                                       length:length
                                      options:options
@@ -241,13 +243,13 @@
 - (nullable id<MTLDepthStencilState>)newDepthStencilStateWithDescriptor:
     (MTLDepthStencilDescriptor *)descriptor
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newDepthStencilStateWithDescriptor:descriptor];
 }
 
 - (nullable id<MTLTexture>)newTextureWithDescriptor:(MTLTextureDescriptor *)descriptor
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newTextureWithDescriptor:descriptor];
 }
 
@@ -256,33 +258,33 @@
                                               plane:(NSUInteger)plane
     API_AVAILABLE(macos(10.11), ios(11.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newTextureWithDescriptor:descriptor iosurface:iosurface plane:plane];
 }
 
 - (nullable id<MTLTexture>)newSharedTextureWithDescriptor:(MTLTextureDescriptor *)descriptor
     API_AVAILABLE(macos(10.14), ios(13.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newSharedTextureWithDescriptor:descriptor];
 }
 
 - (nullable id<MTLTexture>)newSharedTextureWithHandle:(MTLSharedTextureHandle *)sharedHandle
     API_AVAILABLE(macos(10.14), ios(13.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newSharedTextureWithHandle:sharedHandle];
 }
 
 - (nullable id<MTLSamplerState>)newSamplerStateWithDescriptor:(MTLSamplerDescriptor *)descriptor
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newSamplerStateWithDescriptor:descriptor];
 }
 
 - (nullable id<MTLLibrary>)newDefaultLibrary
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newDefaultLibrary];
 }
 
@@ -290,14 +292,14 @@
                                                  error:(__autoreleasing NSError **)error
     API_AVAILABLE(macos(10.12), ios(10.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newDefaultLibraryWithBundle:bundle error:error];
 }
 
 - (nullable id<MTLLibrary>)newLibraryWithFile:(NSString *)filepath
                                         error:(__autoreleasing NSError **)error
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newLibraryWithFile:filepath error:error];
 }
 
@@ -305,14 +307,14 @@
                                        error:(__autoreleasing NSError **)error
     API_AVAILABLE(macos(10.13), ios(11.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newLibraryWithURL:url error:error];
 }
 
 - (nullable id<MTLLibrary>)newLibraryWithData:(dispatch_data_t)data
                                         error:(__autoreleasing NSError **)error
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newLibraryWithData:data error:error];
 }
 
@@ -320,7 +322,7 @@
                                         options:(nullable MTLCompileOptions *)options
                                           error:(__autoreleasing NSError **)error
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newLibraryWithSource:source options:options error:error];
 }
 
@@ -328,7 +330,7 @@
                      options:(nullable MTLCompileOptions *)options
            completionHandler:(MTLNewLibraryCompletionHandler)completionHandler
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return
       [self.real newLibraryWithSource:source options:options completionHandler:completionHandler];
 }
@@ -338,7 +340,7 @@
                                                       error:(__autoreleasing NSError **)error
     API_AVAILABLE(macos(12.0), ios(15.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newLibraryWithStitchedDescriptor:descriptor error:error];
 }
 #endif
@@ -348,7 +350,7 @@
                        completionHandler:(MTLNewLibraryCompletionHandler)completionHandler
     API_AVAILABLE(macos(12.0), ios(15.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   [self.real newLibraryWithStitchedDescriptor:descriptor completionHandler:completionHandler];
 }
 #endif
@@ -357,7 +359,7 @@
 newRenderPipelineStateWithDescriptor:(MTLRenderPipelineDescriptor *)descriptor
                                error:(__autoreleasing NSError **)error
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newRenderPipelineStateWithDescriptor:descriptor error:error];
 }
 
@@ -367,7 +369,7 @@ newRenderPipelineStateWithDescriptor:(MTLRenderPipelineDescriptor *)descriptor
                           reflection:(MTLAutoreleasedRenderPipelineReflection *__nullable)reflection
                                error:(__autoreleasing NSError **)error
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newRenderPipelineStateWithDescriptor:descriptor
                                                  options:options
                                               reflection:reflection
@@ -377,7 +379,7 @@ newRenderPipelineStateWithDescriptor:(MTLRenderPipelineDescriptor *)descriptor
 - (void)newRenderPipelineStateWithDescriptor:(MTLRenderPipelineDescriptor *)descriptor
                            completionHandler:(MTLNewRenderPipelineStateCompletionHandler)completionHandler
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newRenderPipelineStateWithDescriptor:descriptor
                                        completionHandler:completionHandler];
 }
@@ -387,7 +389,7 @@ newRenderPipelineStateWithDescriptor:(MTLRenderPipelineDescriptor *)descriptor
                            completionHandler:
                                (MTLNewRenderPipelineStateWithReflectionCompletionHandler)completionHandler
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newRenderPipelineStateWithDescriptor:descriptor
                                                  options:options
                                        completionHandler:completionHandler];
@@ -397,7 +399,7 @@ newRenderPipelineStateWithDescriptor:(MTLRenderPipelineDescriptor *)descriptor
 newComputePipelineStateWithFunction:(id<MTLFunction>)computeFunction
                               error:(__autoreleasing NSError **)error
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newComputePipelineStateWithFunction:computeFunction error:error];
 }
 
@@ -407,7 +409,7 @@ newComputePipelineStateWithFunction:(id<MTLFunction>)computeFunction
                          reflection:(MTLAutoreleasedComputePipelineReflection *__nullable)reflection
                               error:(__autoreleasing NSError **)error
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newComputePipelineStateWithFunction:computeFunction
                                                 options:options
                                              reflection:reflection
@@ -417,7 +419,7 @@ newComputePipelineStateWithFunction:(id<MTLFunction>)computeFunction
 - (void)newComputePipelineStateWithFunction:(id<MTLFunction>)computeFunction
                           completionHandler:(MTLNewComputePipelineStateCompletionHandler)completionHandler
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newComputePipelineStateWithFunction:computeFunction
                                       completionHandler:completionHandler];
 }
@@ -427,7 +429,7 @@ newComputePipelineStateWithFunction:(id<MTLFunction>)computeFunction
                           completionHandler:
                               (MTLNewComputePipelineStateWithReflectionCompletionHandler)completionHandler
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newComputePipelineStateWithFunction:computeFunction
                                                 options:options
                                       completionHandler:completionHandler];
@@ -440,7 +442,7 @@ newComputePipelineStateWithDescriptor:(MTLComputePipelineDescriptor *)descriptor
                                 error:(__autoreleasing NSError **)error
     API_AVAILABLE(macos(10.11), ios(9.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newComputePipelineStateWithDescriptor:descriptor
                                                   options:options
                                                reflection:reflection
@@ -453,7 +455,7 @@ newComputePipelineStateWithDescriptor:(MTLComputePipelineDescriptor *)descriptor
                                 (MTLNewComputePipelineStateWithReflectionCompletionHandler)completionHandler
     API_AVAILABLE(macos(10.11), ios(9.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newComputePipelineStateWithDescriptor:descriptor
                                                   options:options
                                         completionHandler:completionHandler];
@@ -461,39 +463,39 @@ newComputePipelineStateWithDescriptor:(MTLComputePipelineDescriptor *)descriptor
 
 - (nullable id<MTLFence>)newFence API_AVAILABLE(macos(10.13), ios(10.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newFence];
 }
 
 - (BOOL)supportsFeatureSet:(MTLFeatureSet)featureSet
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real supportsFeatureSet:featureSet];
 }
 
 - (BOOL)supportsFamily:(MTLGPUFamily)gpuFamily API_AVAILABLE(macos(10.15), ios(13.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real supportsFamily:gpuFamily];
 }
 
 - (BOOL)supportsTextureSampleCount:(NSUInteger)sampleCount API_AVAILABLE(macos(10.11), ios(9.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real supportsTextureSampleCount:sampleCount];
 }
 
 - (NSUInteger)minimumLinearTextureAlignmentForPixelFormat:(MTLPixelFormat)format
     API_AVAILABLE(macos(10.13), ios(11.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real minimumLinearTextureAlignmentForPixelFormat:format];
 }
 
 - (NSUInteger)minimumTextureBufferAlignmentForPixelFormat:(MTLPixelFormat)format
     API_AVAILABLE(macos(10.14), ios(12.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real minimumTextureBufferAlignmentForPixelFormat:format];
 }
 
@@ -504,7 +506,7 @@ newRenderPipelineStateWithTileDescriptor:(MTLTileRenderPipelineDescriptor *)desc
                                    error:(__autoreleasing NSError **)error
     API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(11.0), tvos(14.5))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newRenderPipelineStateWithTileDescriptor:descriptor
                                                      options:options
                                                   reflection:reflection
@@ -517,7 +519,7 @@ newRenderPipelineStateWithTileDescriptor:(MTLTileRenderPipelineDescriptor *)desc
                                    (MTLNewRenderPipelineStateWithReflectionCompletionHandler)completionHandler
     API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(11.0), tvos(14.5))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newRenderPipelineStateWithTileDescriptor:descriptor
                                                      options:options
                                            completionHandler:completionHandler];
@@ -541,21 +543,21 @@ newRenderPipelineStateWithTileDescriptor:(MTLTileRenderPipelineDescriptor *)desc
 - (void)getDefaultSamplePositions:(MTLSamplePosition *)positions
                             count:(NSUInteger)count API_AVAILABLE(macos(10.13), ios(11.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real getDefaultSamplePositions:positions count:count];
 }
 
 - (nullable id<MTLArgumentEncoder>)newArgumentEncoderWithArguments:
     (NSArray<MTLArgumentDescriptor *> *)arguments API_AVAILABLE(macos(10.13), ios(11.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newArgumentEncoderWithArguments:arguments];
 }
 
 - (BOOL)supportsRasterizationRateMapWithLayerCount:(NSUInteger)layerCount
     API_AVAILABLE(macos(10.15.4), ios(13.0), macCatalyst(13.4))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real supportsRasterizationRateMapWithLayerCount:layerCount];
 }
 
@@ -563,7 +565,7 @@ newRenderPipelineStateWithTileDescriptor:(MTLTileRenderPipelineDescriptor *)desc
     (MTLRasterizationRateMapDescriptor *)descriptor
     API_AVAILABLE(macos(10.15.4), ios(13.0), macCatalyst(13.4))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newRasterizationRateMapWithDescriptor:descriptor];
 }
 
@@ -573,7 +575,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                                options:(MTLResourceOptions)options
     API_AVAILABLE(macos(10.14), ios(12.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newIndirectCommandBufferWithDescriptor:descriptor
                                            maxCommandCount:maxCount
                                                    options:options];
@@ -581,20 +583,20 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
 
 - (nullable id<MTLEvent>)newEvent API_AVAILABLE(macos(10.14), ios(12.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newEvent];
 }
 
 - (nullable id<MTLSharedEvent>)newSharedEvent API_AVAILABLE(macos(10.14), ios(12.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newSharedEvent];
 }
 
 - (nullable id<MTLSharedEvent>)newSharedEventWithHandle:(MTLSharedEventHandle *)sharedEventHandle
     API_AVAILABLE(macos(10.14), ios(12.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newSharedEventWithHandle:sharedEventHandle];
 }
 
@@ -618,7 +620,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                              sampleCount:(NSUInteger)sampleCount
     API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(13.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real sparseTileSizeWithTextureType:textureType
                                       pixelFormat:pixelFormat
                                       sampleCount:sampleCount];
@@ -636,7 +638,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                        numRegions:(NSUInteger)numRegions
     API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(13.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real convertSparsePixelRegions:pixelRegions
                                 toTileRegions:tileRegions
                                  withTileSize:tileSize
@@ -650,7 +652,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                       numRegions:(NSUInteger)numRegions
     API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(13.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real convertSparseTileRegions:tileRegions
                               toPixelRegions:pixelRegions
                                 withTileSize:tileSize
@@ -672,28 +674,28 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                                                                       error:(NSError **)error
     API_AVAILABLE(macos(10.15), ios(14.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newCounterSampleBufferWithDescriptor:descriptor error:error];
 }
 
 - (void)sampleTimestamps:(MTLTimestamp *)cpuTimestamp
             gpuTimestamp:(MTLTimestamp *)gpuTimestamp API_AVAILABLE(macos(10.15), ios(14.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real sampleTimestamps:cpuTimestamp gpuTimestamp:gpuTimestamp];
 }
 
 - (BOOL)supportsCounterSampling:(MTLCounterSamplingPoint)samplingPoint
     API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real supportsCounterSampling:samplingPoint];
 }
 
 - (BOOL)supportsVertexAmplificationCount:(NSUInteger)count
     API_AVAILABLE(macos(10.15.4), ios(13.0), macCatalyst(13.4))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real supportsVertexAmplificationCount:count];
 }
 
@@ -713,7 +715,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                                               error:(NSError **)error
     API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newDynamicLibrary:library error:error];
 }
 
@@ -721,7 +723,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                                                      error:(NSError **)error
     API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newDynamicLibraryWithURL:url error:error];
 }
 
@@ -729,7 +731,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                                                           error:(NSError **)error
     API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newBinaryArchiveWithDescriptor:descriptor error:error];
 }
 
@@ -741,21 +743,21 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
 - (MTLAccelerationStructureSizes)accelerationStructureSizesWithDescriptor:
     (MTLAccelerationStructureDescriptor *)descriptor API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real accelerationStructureSizesWithDescriptor:descriptor];
 }
 
 - (nullable id<MTLAccelerationStructure>)newAccelerationStructureWithSize:(NSUInteger)size
     API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newAccelerationStructureWithSize:size];
 }
 
 - (nullable id<MTLAccelerationStructure>)newAccelerationStructureWithDescriptor:
     (MTLAccelerationStructureDescriptor *)descriptor API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  NSLog(@"Not hooked %@", NSStringFromSelector(_cmd));
+  METAL_NOT_HOOKED();
   return [self.real newAccelerationStructureWithDescriptor:descriptor];
 }
 

--- a/renderdoc/driver/metal/metal_function.cpp
+++ b/renderdoc/driver/metal/metal_function.cpp
@@ -22,18 +22,12 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#pragma once
+#include "metal_function.h"
+#include "metal_device.h"
 
-#include "metal_common.h"
-
-#define METALCPP_WRAPPED_PROTOCOLS(FUNC) \
-  FUNC(Device);                          \
-  FUNC(Function);                        \
-  FUNC(Library);
-
-#define DECLARE_OBJC_HELPERS(CPPTYPE) \
-  class WrappedMTL##CPPTYPE;          \
-  extern MTL::CPPTYPE *AllocateObjCWrapper(WrappedMTL##CPPTYPE *wrapped);
-
-METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)
-#undef DECLARE_OBJC_HELPERS
+WrappedMTLFunction::WrappedMTLFunction(MTL::Function *realMTLFunction, ResourceId objId,
+                                       WrappedMTLDevice *wrappedMTLDevice)
+    : WrappedMTLObject(realMTLFunction, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
+{
+  wrappedObjC = AllocateObjCWrapper(this);
+}

--- a/renderdoc/driver/metal/metal_function.h
+++ b/renderdoc/driver/metal/metal_function.h
@@ -26,14 +26,16 @@
 
 #include "metal_common.h"
 
-#define METALCPP_WRAPPED_PROTOCOLS(FUNC) \
-  FUNC(Device);                          \
-  FUNC(Function);                        \
-  FUNC(Library);
+class WrappedMTLFunction : public WrappedMTLObject
+{
+public:
+  WrappedMTLFunction(MTL::Function *realMTLFunction, ResourceId objId,
+                     WrappedMTLDevice *wrappedMTLDevice);
 
-#define DECLARE_OBJC_HELPERS(CPPTYPE) \
-  class WrappedMTL##CPPTYPE;          \
-  extern MTL::CPPTYPE *AllocateObjCWrapper(WrappedMTL##CPPTYPE *wrapped);
+  enum
+  {
+    TypeEnum = eResFunction
+  };
 
-METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)
-#undef DECLARE_OBJC_HELPERS
+private:
+};

--- a/renderdoc/driver/metal/metal_function_bridge.mm
+++ b/renderdoc/driver/metal/metal_function_bridge.mm
@@ -1,0 +1,118 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "metal_function.h"
+#include "metal_types_bridge.h"
+
+// Wrapper for MTLFunction
+@implementation ObjCWrappedMTLFunction
+
+// ObjCWrappedMTLFunction specific
+- (id<MTLFunction>)real
+{
+  MTL::Function *real = Unwrap<MTL::Function *>(self.wrappedCPP);
+  return id<MTLFunction>(real);
+}
+
+- (void)dealloc
+{
+  self.wrappedCPP->Dealloc();
+  [super dealloc];
+}
+
+// MTLFunction : based on the protocol defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLLibrrary.h
+
+- (NSString *)label API_AVAILABLE(macos(10.12), ios(10.0))
+{
+  return self.real.label;
+}
+
+- (void)setLabel:value
+{
+  self.real.label = value;
+}
+
+- (id<MTLDevice>)device
+{
+  return id<MTLDevice>(self.wrappedCPP->GetObjCWrappedMTLDevice());
+}
+
+- (MTLFunctionType)functionType
+{
+  return self.real.functionType;
+}
+
+- (MTLPatchType)patchType API_AVAILABLE(macos(10.12), ios(10.0))
+{
+  return self.real.patchType;
+}
+
+- (NSInteger)patchControlPointCount API_AVAILABLE(macos(10.12), ios(10.0))
+{
+  return self.real.patchControlPointCount;
+}
+
+- (NSArray<MTLVertexAttribute *> *)vertexAttributes
+{
+  return self.real.vertexAttributes;
+}
+
+- (NSArray<MTLAttribute *> *)stageInputAttributes API_AVAILABLE(macos(10.12), ios(10.0))
+{
+  return self.real.stageInputAttributes;
+}
+
+- (NSString *)name
+{
+  return self.real.name;
+}
+
+- (NSDictionary<NSString *, MTLFunctionConstant *> *)functionConstantsDictionary
+    API_AVAILABLE(macos(10.12), ios(10.0))
+{
+  return self.real.functionConstantsDictionary;
+}
+
+- (id<MTLArgumentEncoder>)newArgumentEncoderWithBufferIndex:(NSUInteger)bufferIndex
+    API_AVAILABLE(macos(10.13), ios(11.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newArgumentEncoderWithBufferIndex:bufferIndex];
+}
+
+- (id<MTLArgumentEncoder>)newArgumentEncoderWithBufferIndex:(NSUInteger)bufferIndex
+                                                 reflection:(MTLAutoreleasedArgument *__nullable)reflection
+    API_AVAILABLE(macos(10.13), ios(11.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newArgumentEncoderWithBufferIndex:bufferIndex reflection:reflection];
+}
+
+- (MTLFunctionOptions)options API_AVAILABLE(macos(11.0), ios(14.0))
+{
+  return self.real.options;
+}
+
+@end

--- a/renderdoc/driver/metal/metal_hook_bridge.mm
+++ b/renderdoc/driver/metal/metal_hook_bridge.mm
@@ -81,9 +81,15 @@ void MetalHook::RegisterGlobalNonHookedMetalFunctions()
 #undef METAL_FETCH
 }
 
+extern void AppleRegisterRealSymbol(const char *functionName, void *address);
+
 void MetalHook::RegisterGlobalHookedMetalFunctions()
 {
-#define METAL_FUNC(func) METAL.func = &::func;
+#define METAL_FUNC(func)                                                                          \
+  AppleRegisterRealSymbol(STRINGIZE(func), (void *)&::func);                                      \
+  LibraryHooks::RegisterFunctionHook("Metal", FunctionHook(STRINGIZE(func), (void **)&METAL.func, \
+                                                           (void *)&METAL_EXPORT_NAME(func)));
+
   ForEachMetalSupported();
 #undef METAL_FUNC
 }

--- a/renderdoc/driver/metal/metal_library.cpp
+++ b/renderdoc/driver/metal/metal_library.cpp
@@ -22,18 +22,13 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#pragma once
+#include "metal_library.h"
+#include "metal_device.h"
+#include "metal_function.h"
 
-#include "metal_common.h"
-
-#define METALCPP_WRAPPED_PROTOCOLS(FUNC) \
-  FUNC(Device);                          \
-  FUNC(Function);                        \
-  FUNC(Library);
-
-#define DECLARE_OBJC_HELPERS(CPPTYPE) \
-  class WrappedMTL##CPPTYPE;          \
-  extern MTL::CPPTYPE *AllocateObjCWrapper(WrappedMTL##CPPTYPE *wrapped);
-
-METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)
-#undef DECLARE_OBJC_HELPERS
+WrappedMTLLibrary::WrappedMTLLibrary(MTL::Library *realMTLLibrary, ResourceId objId,
+                                     WrappedMTLDevice *wrappedMTLDevice)
+    : WrappedMTLObject(realMTLLibrary, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
+{
+  wrappedObjC = AllocateObjCWrapper(this);
+}

--- a/renderdoc/driver/metal/metal_library.h
+++ b/renderdoc/driver/metal/metal_library.h
@@ -26,14 +26,16 @@
 
 #include "metal_common.h"
 
-#define METALCPP_WRAPPED_PROTOCOLS(FUNC) \
-  FUNC(Device);                          \
-  FUNC(Function);                        \
-  FUNC(Library);
+class WrappedMTLLibrary : public WrappedMTLObject
+{
+public:
+  WrappedMTLLibrary(MTL::Library *realMTLLibrary, ResourceId objId,
+                    WrappedMTLDevice *wrappedMTLDevice);
 
-#define DECLARE_OBJC_HELPERS(CPPTYPE) \
-  class WrappedMTL##CPPTYPE;          \
-  extern MTL::CPPTYPE *AllocateObjCWrapper(WrappedMTL##CPPTYPE *wrapped);
+  enum
+  {
+    TypeEnum = eResLibrary
+  };
 
-METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)
-#undef DECLARE_OBJC_HELPERS
+private:
+};

--- a/renderdoc/driver/metal/metal_library_bridge.mm
+++ b/renderdoc/driver/metal/metal_library_bridge.mm
@@ -1,0 +1,152 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "metal_library.h"
+#include "metal_types_bridge.h"
+
+// Wrapper for MTLLibrary
+@implementation ObjCWrappedMTLLibrary
+
+// ObjCWrappedMTLLibrary specific
+- (id<MTLLibrary>)real
+{
+  MTL::Library *real = Unwrap<MTL::Library *>(self.wrappedCPP);
+  return id<MTLLibrary>(real);
+}
+
+// Use the real MTLLibrary to find methods from messages
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+  id fwd = self.real;
+  return [fwd methodSignatureForSelector:aSelector];
+}
+
+// Forward any unknown messages to the real MTLLibrary
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+  SEL aSelector = [invocation selector];
+
+  if([self.real respondsToSelector:aSelector])
+    [invocation invokeWithTarget:self.real];
+  else
+    [super forwardInvocation:invocation];
+}
+
+// MTLLibrary : based on the protocol defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLLibrrary.h
+
+- (NSString *)label
+{
+  return self.real.label;
+}
+
+- (void)setLabel:value
+{
+  self.real.label = value;
+}
+
+- (id<MTLDevice>)device
+{
+  return id<MTLDevice>(self.wrappedCPP->GetObjCWrappedMTLDevice());
+}
+
+- (nullable id<MTLFunction>)newFunctionWithName:(NSString *)functionName
+{
+  METAL_NOT_HOOKED();
+  return [self.real newFunctionWithName:functionName];
+}
+
+- (nullable id<MTLFunction>)newFunctionWithName:(NSString *)name
+                                 constantValues:(MTLFunctionConstantValues *)constantValues
+                                          error:(__autoreleasing NSError **)error
+    API_AVAILABLE(macos(10.12), ios(10.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newFunctionWithName:name constantValues:constantValues error:error];
+}
+
+- (void)newFunctionWithName:(NSString *)name
+             constantValues:(MTLFunctionConstantValues *)constantValues
+          completionHandler:(void (^)(id<MTLFunction> __nullable function,
+                                      NSError *__nullable error))completionHandler
+    API_AVAILABLE(macos(10.12), ios(10.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newFunctionWithName:name
+                         constantValues:constantValues
+                      completionHandler:completionHandler];
+}
+
+- (void)newFunctionWithDescriptor:(nonnull MTLFunctionDescriptor *)descriptor
+                completionHandler:(void (^)(id<MTLFunction> __nullable function,
+                                            NSError *__nullable error))completionHandler
+    API_AVAILABLE(macos(11.0), ios(14.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newFunctionWithDescriptor:descriptor completionHandler:completionHandler];
+}
+
+- (nullable id<MTLFunction>)newFunctionWithDescriptor:(nonnull MTLFunctionDescriptor *)descriptor
+                                                error:(__autoreleasing NSError **)error
+    API_AVAILABLE(macos(11.0), ios(14.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newFunctionWithDescriptor:descriptor error:error];
+}
+
+- (void)newIntersectionFunctionWithDescriptor:(nonnull MTLIntersectionFunctionDescriptor *)descriptor
+                            completionHandler:(void (^)(id<MTLFunction> __nullable function,
+                                                        NSError *__nullable error))completionHandler
+    API_AVAILABLE(macos(11.0), ios(14.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newIntersectionFunctionWithDescriptor:descriptor
+                                        completionHandler:completionHandler];
+}
+
+- (nullable id<MTLFunction>)newIntersectionFunctionWithDescriptor:
+                                (nonnull MTLIntersectionFunctionDescriptor *)descriptor
+                                                            error:(__autoreleasing NSError **)error
+    API_AVAILABLE(macos(11.0), ios(14.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newIntersectionFunctionWithDescriptor:descriptor error:error];
+}
+
+- (NSArray<NSString *> *)functionNames
+{
+  return self.real.functionNames;
+}
+
+- (MTLLibraryType)type API_AVAILABLE(macos(11.0), ios(14.0))
+{
+  return self.real.type;
+}
+
+- (NSString *)installName API_AVAILABLE(macos(11.0), ios(14.0))
+{
+  return self.real.installName;
+}
+
+@end

--- a/renderdoc/driver/metal/metal_resources.cpp
+++ b/renderdoc/driver/metal/metal_resources.cpp
@@ -22,66 +22,15 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#pragma once
+#include "metal_resources.h"
+#include "metal_device.h"
 
-#include "core/resource_manager.h"
-#include "metal_common.h"
-
-class WrappedMTLDevice;
-
-enum MetalResourceType
+void WrappedMTLObject::Dealloc()
 {
-  eResUnknown = 0,
-  eResDevice,
-  eResLibrary,
-  eResFunction,
-};
-
-DECLARE_REFLECTION_ENUM(MetalResourceType);
-
-struct WrappedMTLObject
-{
-  WrappedMTLObject() = delete;
-  WrappedMTLObject(WrappedMTLDevice *wrappedMTLDevice, CaptureState &captureState)
-      : wrappedObjC(NULL), real(NULL), m_WrappedMTLDevice(wrappedMTLDevice), m_State(captureState)
-  {
-  }
-  WrappedMTLObject(void *mtlObject, ResourceId objId, WrappedMTLDevice *wrappedMTLDevice,
-                   CaptureState &captureState)
-      : wrappedObjC(NULL),
-        real(mtlObject),
-        id(objId),
-        m_WrappedMTLDevice(wrappedMTLDevice),
-        m_State(captureState)
-  {
-  }
-  ~WrappedMTLObject() = default;
-
-  void Dealloc();
-
-  MTL::Device *GetObjCWrappedMTLDevice();
-
-  void *wrappedObjC;
-  void *real;
-  ResourceId id;
-  WrappedMTLDevice *m_WrappedMTLDevice;
-  CaptureState &m_State;
-};
-
-template <typename RealType>
-RealType Unwrap(WrappedMTLObject *obj)
-{
-  if(obj == NULL)
-    return RealType();
-
-  return (RealType)obj->real;
+  // TODO: call the wrapped object destructor
 }
 
-template <typename RealType>
-RealType UnwrapObjC(WrappedMTLObject *obj)
+MTL::Device *WrappedMTLObject::GetObjCWrappedMTLDevice()
 {
-  if(obj == NULL)
-    return RealType();
-
-  return (RealType)obj->wrappedObjC;
+  return UnwrapObjC<MTL::Device *>(m_WrappedMTLDevice);
 }

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -25,7 +25,19 @@
 #pragma once
 
 #include "core/resource_manager.h"
-#include "metal_types.h"
+#include "metal_common.h"
+
+class WrappedMTLDevice;
+
+enum MetalResourceType
+{
+  eResUnknown = 0,
+  eResDevice,
+  eResLibrary,
+  eResFunction,
+};
+
+DECLARE_REFLECTION_ENUM(MetalResourceType);
 
 struct WrappedMTLObject
 {

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -42,8 +42,17 @@ DECLARE_REFLECTION_ENUM(MetalResourceType);
 struct WrappedMTLObject
 {
   WrappedMTLObject() = delete;
-  WrappedMTLObject(void *mtlObject, ResourceId objId, WrappedMTLDevice *wrappedMTLDevice)
-      : wrappedObjC(NULL), real(mtlObject), id(objId), m_WrappedMTLDevice(wrappedMTLDevice)
+  WrappedMTLObject(WrappedMTLDevice *wrappedMTLDevice, CaptureState &captureState)
+      : wrappedObjC(NULL), real(NULL), m_WrappedMTLDevice(wrappedMTLDevice), m_State(captureState)
+  {
+  }
+  WrappedMTLObject(void *mtlObject, ResourceId objId, WrappedMTLDevice *wrappedMTLDevice,
+                   CaptureState &captureState)
+      : wrappedObjC(NULL),
+        real(mtlObject),
+        id(objId),
+        m_WrappedMTLDevice(wrappedMTLDevice),
+        m_State(captureState)
   {
   }
   ~WrappedMTLObject() = default;
@@ -52,6 +61,7 @@ struct WrappedMTLObject
   void *real;
   ResourceId id;
   WrappedMTLDevice *m_WrappedMTLDevice;
+  CaptureState &m_State;
 };
 
 template <typename RealType>

--- a/renderdoc/driver/metal/metal_types_bridge.h
+++ b/renderdoc/driver/metal/metal_types_bridge.h
@@ -27,6 +27,7 @@
 #include "metal_types.h"
 
 #import <Metal/MTLDevice.h>
+#import <Metal/MTLLibrary.h>
 
 // clang-format off
 #define DECLARE_OBJC_WRAPPED_INTERFACES(CPPTYPE)              \

--- a/renderdoc/driver/metal/metal_types_bridge.mm
+++ b/renderdoc/driver/metal/metal_types_bridge.mm
@@ -24,6 +24,7 @@
 
 #include "metal_types_bridge.h"
 #include "metal_device.h"
+#include "metal_library.h"
 
 #define DEFINE_OBJC_HELPERS(CPPTYPE)                                               \
   MTL::CPPTYPE *AllocateObjCWrapper(WrappedMTL##CPPTYPE *wrappedCPP)               \

--- a/renderdoc/driver/metal/official/metal-cpp.cpp
+++ b/renderdoc/driver/metal/official/metal-cpp.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * The MIT License (MIT)
  *
- * Copyright (c) 2019-2022 Baldur Karlsson
+ * Copyright (c) 2022 Baldur Karlsson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description

Some small misc updates to the base work  in commit `Metal: basic hooking and MTLDevice wrapping`

Added wrapped objects for MTLibrary and MTLFunction, these wrapped objects are not currently created or used. The next PR will instantiate these wrapped objects which will require and include the start of  `MetalResourceManager`.

Changed the NSLog message about unhooked APIs to use `RDCWARN` which gives output like this in RenderDoc log file or Diagnostic Log window

`Core     PID  62140: [05:29:22] metal_device_bridge.mm(261) - Warning - Metal ObjCWrappedMTLDevice newTextureWithDescriptor:iosurface:plane: not hooked`