### PR TITLE
 Metal capture support for wrapped MTLRenderPipelineState & MTLTexture

### DIFF
--- a/renderdoc/driver/metal/CMakeLists.txt
+++ b/renderdoc/driver/metal/CMakeLists.txt
@@ -26,6 +26,13 @@ set(sources
     metal_command_buffer.cpp
     metal_command_buffer.h
     metal_command_buffer_bridge.mm
+    metal_render_pipeline_descriptor.cpp
+    metal_render_pipeline_state_bridge.mm
+    metal_render_pipeline_state.cpp
+    metal_render_pipeline_state.h
+    metal_texture.cpp
+    metal_texture.h
+    metal_texture_bridge.mm
     metal_core.cpp
     metal_core.h
     metal_manager.cpp
@@ -33,6 +40,7 @@ set(sources
     metal_init_state.cpp
     metal_helpers_bridge.h
     metal_helpers_bridge.mm
+    metal_stringise.cpp
     official/metal-cpp.h
     official/metal-cpp.cpp)
 

--- a/renderdoc/driver/metal/metal_common.h
+++ b/renderdoc/driver/metal/metal_common.h
@@ -103,6 +103,22 @@ enum class MetalChunk : uint32_t
   MTLCommandBuffer_accelerationStructureCommandEncoder,
   MTLCommandBuffer_pushDebugGroup,
   MTLCommandBuffer_popDebugGroup,
+  MTLTexture_setPurgeableState,
+  MTLTexture_makeAliasable,
+  MTLTexture_getBytes,
+  MTLTexture_getBytes_slice,
+  MTLTexture_replaceRegion,
+  MTLTexture_replaceRegion_slice,
+  MTLTexture_newTextureViewWithPixelFormat,
+  MTLTexture_newTextureViewWithPixelFormat_subset,
+  MTLTexture_newTextureViewWithPixelFormat_subset_swizzle,
+  MTLTexture_newSharedTextureHandle,
+  MTLTexture_remoteStorageTexture,
+  MTLTexture_newRemoteTextureViewForDevice,
+  MTLRenderPipelineState_functionHandleWithFunction,
+  MTLRenderPipelineState_newVisibleFunctionTableWithDescriptor,
+  MTLRenderPipelineState_newIntersectionFunctionTableWithDescriptor,
+  MTLRenderPipelineState_newRenderPipelineStateWithAdditionalBinaryFunctions,
   Max
 };
 

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -42,6 +42,18 @@ public:
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLLibrary *, newLibraryWithSource,
                                           NS::String *source, MTL::CompileOptions *options,
                                           NS::Error **error);
+  DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLRenderPipelineState *,
+                                          newRenderPipelineStateWithDescriptor,
+                                          MTL::RenderPipelineDescriptor *descriptor,
+                                          NS::Error **error);
+  WrappedMTLTexture *newTextureWithDescriptor(MTL::TextureDescriptor *descriptor,
+                                              IOSurfaceRef iosurface, NS::UInteger plane);
+  WrappedMTLTexture *newTextureWithDescriptor(MTL::TextureDescriptor *descriptor);
+  template <typename SerialiserType>
+  bool Serialise_newTextureWithDescriptor(SerialiserType &ser, WrappedMTLTexture *,
+                                          MTL::TextureDescriptor *descriptor, bool frameBufferOnly,
+                                          bool hasIoSurface);
+
   // Non-Serialised MTLDevice APIs
   bool isDepth24Stencil8PixelFormatSupported();
   MTL::ReadWriteTextureTier readWriteTextureSupport();
@@ -89,7 +101,14 @@ private:
   void Create_InitialState(ResourceId id, WrappedMTLObject *live, bool hasData);
   void Apply_InitialState(WrappedMTLObject *live, const MetalInitialContents &initial);
 
+  WrappedMTLTexture *NewTexture(MTL::Texture *realMTLTexture, MTL::TextureDescriptor *descriptor,
+                                bool hasIoSurface);
+
   MetalResourceManager *m_ResourceManager;
+
+  // Back buffer and swap chain emulation
+  Threading::CriticalSection m_PotentialBackBuffersLock;
+  std::unordered_set<WrappedMTLTexture *> m_PotentialBackBuffers;
 
   CaptureState m_State;
 

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -253,8 +253,8 @@
 
 - (nullable id<MTLTexture>)newTextureWithDescriptor:(MTLTextureDescriptor *)descriptor
 {
-  METAL_NOT_HOOKED();
-  return [self.real newTextureWithDescriptor:descriptor];
+  return id<MTLTexture>(GetObjCBridge(
+      self.wrappedCPP->newTextureWithDescriptor((MTL::TextureDescriptor *)descriptor)));
 }
 
 - (nullable id<MTLTexture>)newTextureWithDescriptor:(MTLTextureDescriptor *)descriptor
@@ -262,8 +262,8 @@
                                               plane:(NSUInteger)plane
     API_AVAILABLE(macos(10.11), ios(11.0))
 {
-  METAL_NOT_HOOKED();
-  return [self.real newTextureWithDescriptor:descriptor iosurface:iosurface plane:plane];
+  return id<MTLTexture>(GetObjCBridge(self.wrappedCPP->newTextureWithDescriptor(
+      (MTL::TextureDescriptor *)descriptor, iosurface, plane)));
 }
 
 - (nullable id<MTLTexture>)newSharedTextureWithDescriptor:(MTLTextureDescriptor *)descriptor
@@ -362,8 +362,8 @@
 newRenderPipelineStateWithDescriptor:(MTLRenderPipelineDescriptor *)descriptor
                                error:(__autoreleasing NSError **)error
 {
-  METAL_NOT_HOOKED();
-  return [self.real newRenderPipelineStateWithDescriptor:descriptor error:error];
+  return id<MTLRenderPipelineState>(GetObjCBridge(self.wrappedCPP->newRenderPipelineStateWithDescriptor(
+      (MTL::RenderPipelineDescriptor *)descriptor, (NS::Error **)error)));
 }
 
 - (nullable id<MTLRenderPipelineState>)

--- a/renderdoc/driver/metal/metal_render_pipeline_descriptor.cpp
+++ b/renderdoc/driver/metal/metal_render_pipeline_descriptor.cpp
@@ -1,0 +1,227 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "core/core.h"
+#include "metal_function.h"
+#include "metal_manager.h"
+#include "metal_resources.h"
+
+// MTLRenderPipeline.h
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, MTL::RenderPipelineDescriptor *&el)
+{
+  NS::String *label = NULL;
+  WrappedMTLFunction *vertexFunction = NULL;
+  WrappedMTLFunction *fragmentFunction = NULL;
+  // TODO: vertexDescriptor : MTLVertexDescriptor
+  // TODO: vertexBuffers : MTLPipelineBufferDescriptorArray *
+  // TODO: fragmentBuffers : MTLPipelineBufferDescriptorArray *
+  MTL::RenderPipelineColorAttachmentDescriptor *colorAttachments[MAX_RENDER_PASS_COLOR_ATTACHMENTS];
+  MTL::PixelFormat depthAttachmentPixelFormat;
+  MTL::PixelFormat stencilAttachmentPixelFormat;
+  NS::UInteger sampleCount;
+  bool alphaToCoverageEnabled = false;
+  bool alphaToOneEnabled = false;
+  bool rasterizationEnabled = false;
+  MTL::PrimitiveTopologyClass inputPrimitiveTopology;
+  NS::UInteger rasterSampleCount = 0;
+  NS::UInteger maxTessellationFactor = 0;
+  bool tessellationFactorScaleEnabled = false;
+  MTL::TessellationFactorFormat tessellationFactorFormat;
+  MTL::TessellationControlPointIndexType tessellationControlPointIndexType;
+  MTL::TessellationFactorStepFunction tessellationFactorStepFunction;
+  MTL::Winding tessellationOutputWindingOrder;
+  MTL::TessellationPartitionMode tessellationPartitionMode;
+  bool supportIndirectCommandBuffers = false;
+  NS::UInteger maxVertexAmplificationCount = 0;
+  // TODO: binaryArchives : NSArray<id<MTLBinaryArchive>>
+
+  if(ser.IsReading())
+  {
+    RDCASSERT(el == NULL);
+    el = MTL::RenderPipelineDescriptor::alloc();
+    el = el->init();
+  }
+
+  for(uint32_t i = 0; i < MAX_RENDER_PASS_COLOR_ATTACHMENTS; ++i)
+  {
+    colorAttachments[i] = el->colorAttachments()->object(i);
+  }
+
+  if(ser.IsWriting())
+  {
+    label = el->label();
+    vertexFunction = GetWrapped((MTL::Function *)el->vertexFunction());
+    fragmentFunction = GetWrapped((MTL::Function *)el->fragmentFunction());
+    // TODO: vertexDescriptor : MTLVertexDescriptor
+    // TODO: vertexBuffers : MTLPipelineBufferDescriptorArray *
+    // TODO: fragmentBuffers : MTLPipelineBufferDescriptorArray *
+    // TODO: colorAttachments : MTLRenderPipelineColorAttachmentDescriptorArray *
+    depthAttachmentPixelFormat = el->depthAttachmentPixelFormat();
+    stencilAttachmentPixelFormat = el->stencilAttachmentPixelFormat();
+    sampleCount = el->sampleCount();
+    alphaToCoverageEnabled = el->alphaToCoverageEnabled();
+    alphaToOneEnabled = el->alphaToOneEnabled();
+    rasterizationEnabled = el->rasterizationEnabled();
+    inputPrimitiveTopology = el->inputPrimitiveTopology();
+    rasterSampleCount = el->rasterSampleCount();
+    maxTessellationFactor = el->maxTessellationFactor();
+    tessellationFactorScaleEnabled = el->tessellationFactorScaleEnabled();
+    tessellationFactorFormat = el->tessellationFactorFormat();
+    tessellationControlPointIndexType = el->tessellationControlPointIndexType();
+    tessellationFactorStepFunction = el->tessellationFactorStepFunction();
+    tessellationOutputWindingOrder = el->tessellationOutputWindingOrder();
+    tessellationPartitionMode = el->tessellationPartitionMode();
+    supportIndirectCommandBuffers = el->supportIndirectCommandBuffers();
+    maxVertexAmplificationCount = el->maxVertexAmplificationCount();
+    // TODO: binaryArchives : NSArray<id<MTLBinaryArchive>>
+  }
+  SERIALISE_ELEMENT(label);
+  SERIALISE_ELEMENT(vertexFunction);
+  SERIALISE_ELEMENT(fragmentFunction);
+  // TODO: vertexDescriptor : MTLVertexDescriptor
+  // TODO: vertexBuffers : MTLPipelineBufferDescriptorArray *
+  // TODO: fragmentBuffers : MTLPipelineBufferDescriptorArray *
+  SERIALISE_ELEMENT(colorAttachments);
+  SERIALISE_ELEMENT(depthAttachmentPixelFormat);
+  SERIALISE_ELEMENT(stencilAttachmentPixelFormat);
+  SERIALISE_ELEMENT(sampleCount);
+  SERIALISE_ELEMENT(alphaToCoverageEnabled);
+  SERIALISE_ELEMENT(alphaToOneEnabled);
+  SERIALISE_ELEMENT(rasterizationEnabled);
+  SERIALISE_ELEMENT(inputPrimitiveTopology);
+  SERIALISE_ELEMENT(rasterSampleCount);
+  SERIALISE_ELEMENT(maxTessellationFactor);
+  SERIALISE_ELEMENT(tessellationFactorScaleEnabled);
+  SERIALISE_ELEMENT(tessellationFactorFormat);
+  SERIALISE_ELEMENT(tessellationControlPointIndexType);
+  SERIALISE_ELEMENT(tessellationFactorStepFunction);
+  SERIALISE_ELEMENT(tessellationOutputWindingOrder);
+  SERIALISE_ELEMENT(tessellationPartitionMode);
+  SERIALISE_ELEMENT(supportIndirectCommandBuffers);
+  SERIALISE_ELEMENT(maxVertexAmplificationCount);
+  // TODO: binaryArchives : NSArray<id<MTLBinaryArchive>>
+  if(ser.IsReading())
+  {
+    MetalResourceManager *rm = (MetalResourceManager *)ser.GetUserData();
+    if(rm && IsReplayMode(rm->GetState()))
+    {
+      RDCASSERT(el != NULL);
+      el->setLabel(label);
+
+      el->setVertexFunction(GetObjCBridge(vertexFunction));
+      el->setFragmentFunction(GetObjCBridge(fragmentFunction));
+      // TODO: vertexDescriptor : MTLVertexDescriptor
+      // TODO: vertexBuffers : MTLPipelineBufferDescriptorArray *
+      // TODO: fragmentBuffers : MTLPipelineBufferDescriptorArray *
+      el->setDepthAttachmentPixelFormat(depthAttachmentPixelFormat);
+      el->setStencilAttachmentPixelFormat(stencilAttachmentPixelFormat);
+      el->setSampleCount(sampleCount);
+      el->setAlphaToCoverageEnabled(alphaToCoverageEnabled);
+      el->setAlphaToOneEnabled(alphaToOneEnabled);
+      el->setRasterizationEnabled(rasterizationEnabled);
+      el->setInputPrimitiveTopology(inputPrimitiveTopology);
+      el->setRasterSampleCount(rasterSampleCount);
+      el->setMaxTessellationFactor(maxTessellationFactor);
+      el->setTessellationFactorScaleEnabled(tessellationFactorScaleEnabled);
+      el->setTessellationFactorFormat(tessellationFactorFormat);
+      el->setTessellationControlPointIndexType(tessellationControlPointIndexType);
+      el->setTessellationFactorStepFunction(tessellationFactorStepFunction);
+      el->setTessellationOutputWindingOrder(tessellationOutputWindingOrder);
+      el->setTessellationPartitionMode(tessellationPartitionMode);
+      el->setSupportIndirectCommandBuffers(supportIndirectCommandBuffers);
+      el->setMaxVertexAmplificationCount(maxVertexAmplificationCount);
+      // TODO: binaryArchives : NSArray<id<MTLBinaryArchive>>
+    }
+  }
+}
+
+// MTLRenderPipelineColorAttachmentDescriptor
+// MTLPixelFormat pixelFormat;
+// BOOL blendingEnabled;
+// MTLBlendFactor sourceRGBBlendFactor;
+// MTLBlendFactor destinationRGBBlendFactor;
+// MTLBlendOperation rgbBlendOperation;
+// MTLBlendFactor sourceAlphaBlendFactor;
+// MTLBlendFactor destinationAlphaBlendFactor;
+// MTLBlendOperation alphaBlendOperation;
+// MTLColorWriteMask writeMask;
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, MTL::RenderPipelineColorAttachmentDescriptor *&el)
+{
+  MTL::PixelFormat pixelFormat;
+  bool blendingEnabled;
+  MTL::BlendFactor sourceRGBBlendFactor;
+  MTL::BlendFactor destinationRGBBlendFactor;
+  MTL::BlendOperation rgbBlendOperation;
+  MTL::BlendFactor sourceAlphaBlendFactor;
+  MTL::BlendFactor destinationAlphaBlendFactor;
+  MTL::BlendOperation alphaBlendOperation;
+  MTL::ColorWriteMask writeMask;
+
+  if(ser.IsWriting())
+  {
+    pixelFormat = el->pixelFormat();
+    blendingEnabled = el->blendingEnabled();
+    sourceRGBBlendFactor = el->sourceRGBBlendFactor();
+    destinationRGBBlendFactor = el->destinationRGBBlendFactor();
+    rgbBlendOperation = el->rgbBlendOperation();
+    sourceAlphaBlendFactor = el->sourceAlphaBlendFactor();
+    destinationAlphaBlendFactor = el->destinationAlphaBlendFactor();
+    alphaBlendOperation = el->alphaBlendOperation();
+    writeMask = el->writeMask();
+  }
+
+  SERIALISE_ELEMENT(pixelFormat);
+  SERIALISE_ELEMENT(blendingEnabled);
+  SERIALISE_ELEMENT(sourceRGBBlendFactor);
+  SERIALISE_ELEMENT(destinationRGBBlendFactor);
+  SERIALISE_ELEMENT(rgbBlendOperation);
+  SERIALISE_ELEMENT(sourceAlphaBlendFactor);
+  SERIALISE_ELEMENT(destinationAlphaBlendFactor);
+  SERIALISE_ELEMENT(alphaBlendOperation);
+  SERIALISE_ELEMENT(writeMask);
+
+  if(ser.IsReading())
+  {
+    MetalResourceManager *rm = (MetalResourceManager *)ser.GetUserData();
+    if(rm && IsReplayMode(rm->GetState()))
+    {
+      RDCASSERT(el != NULL);
+      el->setPixelFormat(pixelFormat);
+      el->setBlendingEnabled(blendingEnabled);
+      el->setSourceRGBBlendFactor(sourceRGBBlendFactor);
+      el->setDestinationRGBBlendFactor(destinationRGBBlendFactor);
+      el->setRgbBlendOperation(rgbBlendOperation);
+      el->setSourceAlphaBlendFactor(sourceAlphaBlendFactor);
+      el->setDestinationAlphaBlendFactor(destinationAlphaBlendFactor);
+      el->setAlphaBlendOperation(alphaBlendOperation);
+      el->setWriteMask(writeMask);
+    }
+  }
+}
+
+INSTANTIATE_SERIALISE_TYPE(MTL::RenderPipelineDescriptor *);
+INSTANTIATE_SERIALISE_TYPE(MTL::RenderPipelineColorAttachmentDescriptor *);

--- a/renderdoc/driver/metal/metal_render_pipeline_state.cpp
+++ b/renderdoc/driver/metal/metal_render_pipeline_state.cpp
@@ -22,50 +22,14 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#include "metal_resources.h"
-#include "metal_command_buffer.h"
-#include "metal_command_queue.h"
-#include "metal_device.h"
-#include "metal_function.h"
-#include "metal_library.h"
 #include "metal_render_pipeline_state.h"
-#include "metal_texture.h"
+#include "core/core.h"
 
-ResourceId GetResID(WrappedMTLObject *obj)
+WrappedMTLRenderPipelineState::WrappedMTLRenderPipelineState(
+    MTL::RenderPipelineState *realMTLRenderPipelineState, ResourceId objId,
+    WrappedMTLDevice *wrappedMTLDevice)
+    : WrappedMTLObject(realMTLRenderPipelineState, objId, wrappedMTLDevice,
+                       wrappedMTLDevice->GetStateRef())
 {
-  if(obj == NULL)
-    return ResourceId();
-
-  return obj->m_ID;
-}
-
-#define IMPLEMENT_WRAPPED_TYPE_HELPERS(CPPTYPE)                                          \
-  MTL::CPPTYPE *Unwrap(WrappedMTL##CPPTYPE *obj) { return Unwrap<MTL::CPPTYPE *>(obj); } \
-  MTL::CPPTYPE *GetObjCBridge(WrappedMTL##CPPTYPE *obj)                                  \
-  {                                                                                      \
-    return GetObjCBridge<MTL::CPPTYPE *>(obj);                                           \
-  }
-
-METALCPP_WRAPPED_PROTOCOLS(IMPLEMENT_WRAPPED_TYPE_HELPERS)
-#undef IMPLEMENT_WRAPPED_TYPE_HELPERS
-
-void WrappedMTLObject::Dealloc()
-{
-  // TODO: call the wrapped object destructor
-}
-
-MetalResourceManager *WrappedMTLObject::GetResourceManager()
-{
-  return m_WrappedMTLDevice->GetResourceManager();
-}
-
-MTL::Device *WrappedMTLObject::GetObjCBridgeMTLDevice()
-{
-  return GetObjCBridge(m_WrappedMTLDevice);
-}
-
-MetalResourceRecord::~MetalResourceRecord()
-{
-  if(m_Type == eResCommandBuffer)
-    SAFE_DELETE(cmdInfo);
+  m_ObjcBridge = AllocateObjCBridge(this);
 }

--- a/renderdoc/driver/metal/metal_render_pipeline_state.h
+++ b/renderdoc/driver/metal/metal_render_pipeline_state.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "metal_common.h"
+#include "metal_device.h"
+#include "metal_resources.h"
+
+class WrappedMTLRenderPipelineState : public WrappedMTLObject
+{
+public:
+  WrappedMTLRenderPipelineState(MTL::RenderPipelineState *realMTLRenderPipelineState,
+                                ResourceId objId, WrappedMTLDevice *wrappedMTLDevice);
+
+  enum
+  {
+    TypeEnum = eResRenderPipelineState
+  };
+
+private:
+};

--- a/renderdoc/driver/metal/metal_render_pipeline_state_bridge.mm
+++ b/renderdoc/driver/metal/metal_render_pipeline_state_bridge.mm
@@ -1,0 +1,148 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "metal_render_pipeline_state.h"
+#include "metal_types_bridge.h"
+
+// Bridge for MTLRenderPipelineState
+@implementation ObjCBridgeMTLRenderPipelineState
+
+// ObjCBridgeMTLRenderPipelineState specific
+- (id<MTLRenderPipelineState>)real
+{
+  return id<MTLRenderPipelineState>(Unwrap(self.wrappedCPP));
+}
+
+- (void)dealloc
+{
+  self.wrappedCPP->Dealloc();
+  [super dealloc];
+}
+
+// Use the real MTLRenderPipelineState to find methods from messages
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+  id fwd = self.real;
+  return [fwd methodSignatureForSelector:aSelector];
+}
+
+// Forward any unknown messages to the real MTLRenderPipelineState
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+  SEL aSelector = [invocation selector];
+
+  if([self.real respondsToSelector:aSelector])
+    [invocation invokeWithTarget:self.real];
+  else
+    [super forwardInvocation:invocation];
+}
+
+// MTLRenderPipelineState : based on the protocol defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLRenderPipeline.h
+
+- (nullable NSString *)label
+{
+  return self.real.label;
+}
+
+- (id<MTLDevice>)device
+{
+  return id<MTLDevice>(self.wrappedCPP->GetObjCBridgeMTLDevice());
+}
+
+- (NSUInteger)maxTotalThreadsPerThreadgroup
+    API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(11.0), tvos(14.5))
+{
+  return self.real.maxTotalThreadsPerThreadgroup;
+}
+
+- (BOOL)threadgroupSizeMatchesTileSize
+    API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(11.0), tvos(14.5))
+{
+  return self.real.threadgroupSizeMatchesTileSize;
+}
+
+- (NSUInteger)imageblockSampleLength
+    API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(11.0), tvos(14.5))
+{
+  return self.real.imageblockSampleLength;
+}
+
+- (NSUInteger)imageblockMemoryLengthForDimensions:(MTLSize)imageblockDimensions
+    API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(11.0), tvos(14.5))
+{
+  return [self.real imageblockMemoryLengthForDimensions:imageblockDimensions];
+}
+
+- (BOOL)supportIndirectCommandBuffers API_AVAILABLE(macos(10.14), ios(12.0))
+{
+  return self.real.supportIndirectCommandBuffers;
+}
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
+- (nullable id<MTLFunctionHandle>)functionHandleWithFunction:(id<MTLFunction>)function
+                                                       stage:(MTLRenderStages)stage
+    API_AVAILABLE(macos(12.0), ios(15.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real functionHandleWithFunction:function stage:stage];
+}
+#endif
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
+- (nullable id<MTLVisibleFunctionTable>)newVisibleFunctionTableWithDescriptor:
+                                            (MTLVisibleFunctionTableDescriptor *__nonnull)descriptor
+                                                                        stage:(MTLRenderStages)stage
+    API_AVAILABLE(macos(12.0), ios(15.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newVisibleFunctionTableWithDescriptor:descriptor stage:stage];
+}
+#endif
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
+- (nullable id<MTLIntersectionFunctionTable>)
+newIntersectionFunctionTableWithDescriptor:(MTLIntersectionFunctionTableDescriptor *_Nonnull)descriptor
+                                     stage:(MTLRenderStages)stage
+    API_AVAILABLE(macos(12.0), ios(15.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newIntersectionFunctionTableWithDescriptor:descriptor stage:stage];
+}
+#endif
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
+- (nullable id<MTLRenderPipelineState>)
+newRenderPipelineStateWithAdditionalBinaryFunctions:
+    (nonnull MTLRenderPipelineFunctionsDescriptor *)additionalBinaryFunctions
+                                              error:(__autoreleasing NSError **)error
+    API_AVAILABLE(macos(12.0), ios(15.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newRenderPipelineStateWithAdditionalBinaryFunctions:additionalBinaryFunctions
+                                                                  error:error];
+}
+#endif
+
+@end

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -40,6 +40,8 @@ enum MetalResourceType
   eResDevice,
   eResLibrary,
   eResFunction,
+  eResRenderPipelineState,
+  eResTexture
 };
 
 DECLARE_REFLECTION_ENUM(MetalResourceType);

--- a/renderdoc/driver/metal/metal_stringise.cpp
+++ b/renderdoc/driver/metal/metal_stringise.cpp
@@ -1,0 +1,471 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "metal_common.h"
+
+#define MTL_STRINGISE_ENUM(a) STRINGISE_ENUM_CLASS_NAMED(a, "MTL" #a)
+#define MTL_STRINGISE_BITFIELD_BIT(a) STRINGISE_BITFIELD_CLASS_BIT_NAMED(a, "MTL" #a)
+
+template <>
+rdcstr DoStringise(const MTL::PixelFormat &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::PixelFormat)
+  {
+    MTL_STRINGISE_ENUM(PixelFormatInvalid);
+
+    /* Normal 8 bit formats */
+    MTL_STRINGISE_ENUM(PixelFormatA8Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatR8Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatR8Unorm_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatR8Snorm);
+    MTL_STRINGISE_ENUM(PixelFormatR8Uint);
+    MTL_STRINGISE_ENUM(PixelFormatR8Sint);
+
+    /* Normal 16 bit formats */
+    MTL_STRINGISE_ENUM(PixelFormatR16Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatR16Snorm);
+    MTL_STRINGISE_ENUM(PixelFormatR16Uint);
+    MTL_STRINGISE_ENUM(PixelFormatR16Sint);
+    MTL_STRINGISE_ENUM(PixelFormatR16Float);
+
+    MTL_STRINGISE_ENUM(PixelFormatRG8Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatRG8Unorm_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatRG8Snorm);
+    MTL_STRINGISE_ENUM(PixelFormatRG8Uint);
+    MTL_STRINGISE_ENUM(PixelFormatRG8Sint);
+
+    /* Packed 16 bit formats */
+
+    MTL_STRINGISE_ENUM(PixelFormatB5G6R5Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatA1BGR5Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatABGR4Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatBGR5A1Unorm);
+
+    /* Normal 32 bit formats */
+
+    MTL_STRINGISE_ENUM(PixelFormatR32Uint);
+    MTL_STRINGISE_ENUM(PixelFormatR32Sint);
+    MTL_STRINGISE_ENUM(PixelFormatR32Float);
+
+    MTL_STRINGISE_ENUM(PixelFormatRG16Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatRG16Snorm);
+    MTL_STRINGISE_ENUM(PixelFormatRG16Uint);
+    MTL_STRINGISE_ENUM(PixelFormatRG16Sint);
+    MTL_STRINGISE_ENUM(PixelFormatRG16Float);
+
+    MTL_STRINGISE_ENUM(PixelFormatRGBA8Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA8Unorm_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA8Snorm);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA8Uint);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA8Sint);
+
+    MTL_STRINGISE_ENUM(PixelFormatBGRA8Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatBGRA8Unorm_sRGB);
+
+    /* Packed 32 bit formats */
+
+    MTL_STRINGISE_ENUM(PixelFormatRGB10A2Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatRGB10A2Uint);
+
+    MTL_STRINGISE_ENUM(PixelFormatRG11B10Float);
+    MTL_STRINGISE_ENUM(PixelFormatRGB9E5Float);
+
+    MTL_STRINGISE_ENUM(PixelFormatBGR10A2Unorm);
+
+    MTL_STRINGISE_ENUM(PixelFormatBGR10_XR);
+    MTL_STRINGISE_ENUM(PixelFormatBGR10_XR_sRGB);
+
+    /* Normal 64 bit formats */
+
+    MTL_STRINGISE_ENUM(PixelFormatRG32Uint);
+    MTL_STRINGISE_ENUM(PixelFormatRG32Sint);
+    MTL_STRINGISE_ENUM(PixelFormatRG32Float);
+
+    MTL_STRINGISE_ENUM(PixelFormatRGBA16Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA16Snorm);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA16Uint);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA16Sint);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA16Float);
+
+    MTL_STRINGISE_ENUM(PixelFormatBGRA10_XR);
+    MTL_STRINGISE_ENUM(PixelFormatBGRA10_XR_sRGB);
+
+    /* Normal 128 bit formats */
+
+    MTL_STRINGISE_ENUM(PixelFormatRGBA32Uint);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA32Sint);
+    MTL_STRINGISE_ENUM(PixelFormatRGBA32Float);
+
+    /* Compressed formats. */
+
+    /* S3TC/DXT */
+    MTL_STRINGISE_ENUM(PixelFormatBC1_RGBA);
+    MTL_STRINGISE_ENUM(PixelFormatBC1_RGBA_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatBC2_RGBA);
+    MTL_STRINGISE_ENUM(PixelFormatBC2_RGBA_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatBC3_RGBA);
+    MTL_STRINGISE_ENUM(PixelFormatBC3_RGBA_sRGB);
+
+    /* RGTC */
+    MTL_STRINGISE_ENUM(PixelFormatBC4_RUnorm);
+    MTL_STRINGISE_ENUM(PixelFormatBC4_RSnorm);
+    MTL_STRINGISE_ENUM(PixelFormatBC5_RGUnorm);
+    MTL_STRINGISE_ENUM(PixelFormatBC5_RGSnorm);
+
+    /* BPTC */
+    MTL_STRINGISE_ENUM(PixelFormatBC6H_RGBFloat);
+    MTL_STRINGISE_ENUM(PixelFormatBC6H_RGBUfloat);
+    MTL_STRINGISE_ENUM(PixelFormatBC7_RGBAUnorm);
+    MTL_STRINGISE_ENUM(PixelFormatBC7_RGBAUnorm_sRGB);
+
+    /* PVRTC */
+    MTL_STRINGISE_ENUM(PixelFormatPVRTC_RGB_2BPP);
+    MTL_STRINGISE_ENUM(PixelFormatPVRTC_RGB_2BPP_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatPVRTC_RGB_4BPP);
+    MTL_STRINGISE_ENUM(PixelFormatPVRTC_RGB_4BPP_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatPVRTC_RGBA_2BPP);
+    MTL_STRINGISE_ENUM(PixelFormatPVRTC_RGBA_2BPP_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatPVRTC_RGBA_4BPP);
+    MTL_STRINGISE_ENUM(PixelFormatPVRTC_RGBA_4BPP_sRGB);
+
+    /* ETC2 */
+    MTL_STRINGISE_ENUM(PixelFormatEAC_R11Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatEAC_R11Snorm);
+    MTL_STRINGISE_ENUM(PixelFormatEAC_RG11Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatEAC_RG11Snorm);
+    MTL_STRINGISE_ENUM(PixelFormatEAC_RGBA8);
+    MTL_STRINGISE_ENUM(PixelFormatEAC_RGBA8_sRGB);
+
+    MTL_STRINGISE_ENUM(PixelFormatETC2_RGB8);
+    MTL_STRINGISE_ENUM(PixelFormatETC2_RGB8_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatETC2_RGB8A1);
+    MTL_STRINGISE_ENUM(PixelFormatETC2_RGB8A1_sRGB);
+
+    /* ASTC */
+    MTL_STRINGISE_ENUM(PixelFormatASTC_4x4_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_5x4_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_5x5_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_6x5_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_6x6_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_8x5_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_8x6_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_8x8_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x5_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x6_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x8_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x10_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_12x10_sRGB);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_12x12_sRGB);
+
+    MTL_STRINGISE_ENUM(PixelFormatASTC_4x4_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_5x4_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_5x5_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_6x5_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_6x6_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_8x5_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_8x6_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_8x8_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x5_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x6_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x8_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x10_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_12x10_LDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_12x12_LDR);
+
+    // ASTC HDR (High Dynamic Range) Formats
+    MTL_STRINGISE_ENUM(PixelFormatASTC_4x4_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_5x4_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_5x5_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_6x5_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_6x6_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_8x5_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_8x6_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_8x8_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x5_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x6_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x8_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_10x10_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_12x10_HDR);
+    MTL_STRINGISE_ENUM(PixelFormatASTC_12x12_HDR);
+
+    MTL_STRINGISE_ENUM(PixelFormatGBGR422);
+    MTL_STRINGISE_ENUM(PixelFormatBGRG422);
+
+    /* Depth */
+
+    MTL_STRINGISE_ENUM(PixelFormatDepth16Unorm);
+    MTL_STRINGISE_ENUM(PixelFormatDepth32Float);
+
+    /* Stencil */
+
+    MTL_STRINGISE_ENUM(PixelFormatStencil8);
+
+    /* Depth Stencil */
+
+    MTL_STRINGISE_ENUM(PixelFormatDepth24Unorm_Stencil8);
+    MTL_STRINGISE_ENUM(PixelFormatDepth32Float_Stencil8);
+
+    MTL_STRINGISE_ENUM(PixelFormatX32_Stencil8);
+    MTL_STRINGISE_ENUM(PixelFormatX24_Stencil8);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::PrimitiveTopologyClass &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::PrimitiveTopologyClass)
+  {
+    MTL_STRINGISE_ENUM(PrimitiveTopologyClassUnspecified);
+    MTL_STRINGISE_ENUM(PrimitiveTopologyClassPoint);
+    MTL_STRINGISE_ENUM(PrimitiveTopologyClassLine);
+    MTL_STRINGISE_ENUM(PrimitiveTopologyClassTriangle);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::Winding &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::Winding)
+  {
+    MTL_STRINGISE_ENUM(WindingClockwise);
+    MTL_STRINGISE_ENUM(WindingCounterClockwise);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::TessellationFactorFormat &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::TessellationFactorFormat)
+  {
+    MTL_STRINGISE_ENUM(TessellationFactorFormatHalf);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::TessellationControlPointIndexType &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::TessellationControlPointIndexType)
+  {
+    MTL_STRINGISE_ENUM(TessellationControlPointIndexTypeNone);
+    MTL_STRINGISE_ENUM(TessellationControlPointIndexTypeUInt16);
+    MTL_STRINGISE_ENUM(TessellationControlPointIndexTypeUInt32);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::TessellationFactorStepFunction &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::TessellationFactorStepFunction)
+  {
+    MTL_STRINGISE_ENUM(TessellationFactorStepFunctionConstant);
+    MTL_STRINGISE_ENUM(TessellationFactorStepFunctionPerPatch);
+    MTL_STRINGISE_ENUM(TessellationFactorStepFunctionPerInstance);
+    MTL_STRINGISE_ENUM(TessellationFactorStepFunctionPerPatchAndPerInstance);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::TessellationPartitionMode &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::TessellationPartitionMode)
+  {
+    MTL_STRINGISE_ENUM(TessellationPartitionModePow2);
+    MTL_STRINGISE_ENUM(TessellationPartitionModeInteger);
+    MTL_STRINGISE_ENUM(TessellationPartitionModeFractionalOdd);
+    MTL_STRINGISE_ENUM(TessellationPartitionModeFractionalEven);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::CPUCacheMode &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::CPUCacheMode)
+  {
+    MTL_STRINGISE_ENUM(CPUCacheModeDefaultCache);
+    MTL_STRINGISE_ENUM(CPUCacheModeWriteCombined);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::StorageMode &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::StorageMode)
+  {
+    MTL_STRINGISE_ENUM(StorageModeShared);
+    MTL_STRINGISE_ENUM(StorageModeManaged);
+    MTL_STRINGISE_ENUM(StorageModePrivate);
+    MTL_STRINGISE_ENUM(StorageModeMemoryless);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::HazardTrackingMode &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::HazardTrackingMode)
+  {
+    MTL_STRINGISE_ENUM(HazardTrackingModeDefault);
+    MTL_STRINGISE_ENUM(HazardTrackingModeUntracked);
+    MTL_STRINGISE_ENUM(HazardTrackingModeTracked);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::ResourceOptions &el)
+{
+  BEGIN_BITFIELD_STRINGISE(MTL::ResourceOptions)
+  {
+    // MTLResourceCPUCacheModeDefaultCache
+    // MTLResourceStorageModeShared
+    // MTLResourceHazardTrackingModeDefault
+    // are all the same value (0)
+    STRINGISE_BITFIELD_CLASS_BIT_NAMED(ResourceCPUCacheModeDefaultCache,
+                                       "MTLResourceCPUCacheModeDefaultCache | "
+                                       "MTLResourceStorageModeShared | "
+                                       "MTLResourceHazardTrackingModeDefault");
+
+    MTL_STRINGISE_BITFIELD_BIT(ResourceCPUCacheModeWriteCombined);
+
+    MTL_STRINGISE_BITFIELD_BIT(ResourceStorageModeManaged);
+    MTL_STRINGISE_BITFIELD_BIT(ResourceStorageModePrivate);
+    MTL_STRINGISE_BITFIELD_BIT(ResourceStorageModeMemoryless);
+
+    MTL_STRINGISE_BITFIELD_BIT(ResourceHazardTrackingModeUntracked);
+    MTL_STRINGISE_BITFIELD_BIT(ResourceHazardTrackingModeTracked);
+  }
+  END_BITFIELD_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::TextureType &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::TextureType)
+  {
+    MTL_STRINGISE_ENUM(TextureType1D);
+    MTL_STRINGISE_ENUM(TextureType1DArray);
+    MTL_STRINGISE_ENUM(TextureType2D);
+    MTL_STRINGISE_ENUM(TextureType2DArray);
+    MTL_STRINGISE_ENUM(TextureType2DMultisample);
+    MTL_STRINGISE_ENUM(TextureTypeCube);
+    MTL_STRINGISE_ENUM(TextureTypeCubeArray);
+    MTL_STRINGISE_ENUM(TextureType3D);
+    MTL_STRINGISE_ENUM(TextureType2DMultisampleArray);
+    MTL_STRINGISE_ENUM(TextureTypeTextureBuffer);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::TextureUsage &el)
+{
+  BEGIN_BITFIELD_STRINGISE(MTL::TextureUsage)
+  {
+    MTL_STRINGISE_BITFIELD_BIT(TextureUsageUnknown);
+    MTL_STRINGISE_BITFIELD_BIT(TextureUsageShaderRead);
+    MTL_STRINGISE_BITFIELD_BIT(TextureUsageShaderWrite);
+    MTL_STRINGISE_BITFIELD_BIT(TextureUsageRenderTarget);
+    MTL_STRINGISE_BITFIELD_BIT(TextureUsagePixelFormatView);
+  }
+  END_BITFIELD_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::TextureSwizzle &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::TextureSwizzle)
+  {
+    MTL_STRINGISE_ENUM(TextureSwizzleZero);
+    MTL_STRINGISE_ENUM(TextureSwizzleOne);
+    MTL_STRINGISE_ENUM(TextureSwizzleRed);
+    MTL_STRINGISE_ENUM(TextureSwizzleGreen);
+    MTL_STRINGISE_ENUM(TextureSwizzleBlue);
+    MTL_STRINGISE_ENUM(TextureSwizzleAlpha);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::BlendFactor &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::BlendFactor)
+  {
+    MTL_STRINGISE_ENUM(BlendFactorZero);
+    MTL_STRINGISE_ENUM(BlendFactorOne);
+    MTL_STRINGISE_ENUM(BlendFactorSourceColor);
+    MTL_STRINGISE_ENUM(BlendFactorOneMinusSourceColor);
+    MTL_STRINGISE_ENUM(BlendFactorSourceAlpha);
+    MTL_STRINGISE_ENUM(BlendFactorOneMinusSourceAlpha);
+    MTL_STRINGISE_ENUM(BlendFactorDestinationColor);
+    MTL_STRINGISE_ENUM(BlendFactorOneMinusDestinationColor);
+    MTL_STRINGISE_ENUM(BlendFactorOneMinusDestinationAlpha);
+    MTL_STRINGISE_ENUM(BlendFactorSourceAlphaSaturated);
+    MTL_STRINGISE_ENUM(BlendFactorBlendColor);
+    MTL_STRINGISE_ENUM(BlendFactorOneMinusBlendColor);
+    MTL_STRINGISE_ENUM(BlendFactorBlendAlpha);
+    MTL_STRINGISE_ENUM(BlendFactorOneMinusBlendAlpha);
+    MTL_STRINGISE_ENUM(BlendFactorSource1Color);
+    MTL_STRINGISE_ENUM(BlendFactorOneMinusSource1Color);
+    MTL_STRINGISE_ENUM(BlendFactorSource1Alpha);
+    MTL_STRINGISE_ENUM(BlendFactorOneMinusSource1Alpha);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::BlendOperation &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::BlendOperation)
+  {
+    MTL_STRINGISE_ENUM(BlendOperationAdd);
+    MTL_STRINGISE_ENUM(BlendOperationSubtract);
+    MTL_STRINGISE_ENUM(BlendOperationReverseSubtract);
+    MTL_STRINGISE_ENUM(BlendOperationMin);
+    MTL_STRINGISE_ENUM(BlendOperationMax);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
+rdcstr DoStringise(const MTL::ColorWriteMask &el)
+{
+  BEGIN_BITFIELD_STRINGISE(MTL::ColorWriteMask)
+  {
+    MTL_STRINGISE_BITFIELD_BIT(ColorWriteMaskNone);
+    MTL_STRINGISE_BITFIELD_BIT(ColorWriteMaskRed);
+    MTL_STRINGISE_BITFIELD_BIT(ColorWriteMaskGreen);
+    MTL_STRINGISE_BITFIELD_BIT(ColorWriteMaskBlue);
+    MTL_STRINGISE_BITFIELD_BIT(ColorWriteMaskAlpha);
+    MTL_STRINGISE_BITFIELD_BIT(ColorWriteMaskAll);
+  }
+  END_BITFIELD_STRINGISE()
+}

--- a/renderdoc/driver/metal/metal_texture.cpp
+++ b/renderdoc/driver/metal/metal_texture.cpp
@@ -22,50 +22,12 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#include "metal_resources.h"
-#include "metal_command_buffer.h"
-#include "metal_command_queue.h"
-#include "metal_device.h"
-#include "metal_function.h"
-#include "metal_library.h"
-#include "metal_render_pipeline_state.h"
 #include "metal_texture.h"
+#include "metal_device.h"
 
-ResourceId GetResID(WrappedMTLObject *obj)
+WrappedMTLTexture::WrappedMTLTexture(MTL::Texture *realMTLTexture, ResourceId objId,
+                                     WrappedMTLDevice *wrappedMTLDevice)
+    : WrappedMTLObject(realMTLTexture, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  if(obj == NULL)
-    return ResourceId();
-
-  return obj->m_ID;
-}
-
-#define IMPLEMENT_WRAPPED_TYPE_HELPERS(CPPTYPE)                                          \
-  MTL::CPPTYPE *Unwrap(WrappedMTL##CPPTYPE *obj) { return Unwrap<MTL::CPPTYPE *>(obj); } \
-  MTL::CPPTYPE *GetObjCBridge(WrappedMTL##CPPTYPE *obj)                                  \
-  {                                                                                      \
-    return GetObjCBridge<MTL::CPPTYPE *>(obj);                                           \
-  }
-
-METALCPP_WRAPPED_PROTOCOLS(IMPLEMENT_WRAPPED_TYPE_HELPERS)
-#undef IMPLEMENT_WRAPPED_TYPE_HELPERS
-
-void WrappedMTLObject::Dealloc()
-{
-  // TODO: call the wrapped object destructor
-}
-
-MetalResourceManager *WrappedMTLObject::GetResourceManager()
-{
-  return m_WrappedMTLDevice->GetResourceManager();
-}
-
-MTL::Device *WrappedMTLObject::GetObjCBridgeMTLDevice()
-{
-  return GetObjCBridge(m_WrappedMTLDevice);
-}
-
-MetalResourceRecord::~MetalResourceRecord()
-{
-  if(m_Type == eResCommandBuffer)
-    SAFE_DELETE(cmdInfo);
+  m_ObjcBridge = AllocateObjCBridge(this);
 }

--- a/renderdoc/driver/metal/metal_texture.h
+++ b/renderdoc/driver/metal/metal_texture.h
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "metal_common.h"
+
+class WrappedMTLTexture : public WrappedMTLObject
+{
+public:
+  WrappedMTLTexture(MTL::Texture *realMTLTexture, ResourceId objId,
+                    WrappedMTLDevice *wrappedMTLDevice);
+
+  enum
+  {
+    TypeEnum = eResTexture
+  };
+
+private:
+};

--- a/renderdoc/driver/metal/metal_texture_bridge.mm
+++ b/renderdoc/driver/metal/metal_texture_bridge.mm
@@ -1,0 +1,367 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "metal_texture.h"
+#include "metal_types_bridge.h"
+
+// Bridge for MTLTexture
+@implementation ObjCBridgeMTLTexture
+
+// ObjCBridgeMTLTexture specific
+- (id<MTLTexture>)real
+{
+  return id<MTLTexture>(Unwrap(self.wrappedCPP));
+}
+
+- (void)dealloc
+{
+  self.wrappedCPP->Dealloc();
+  [super dealloc];
+}
+
+// Use the real MTLTexture to find methods from messages
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+  id fwd = self.real;
+  return [fwd methodSignatureForSelector:aSelector];
+}
+
+// Forward any unknown messages to the real MTLTexture
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+  SEL aSelector = [invocation selector];
+
+  if([self.real respondsToSelector:aSelector])
+    [invocation invokeWithTarget:self.real];
+  else
+    [super forwardInvocation:invocation];
+}
+
+// MTLResource : based on the protocol defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLResource.h
+
+- (nullable NSString *)label
+{
+  return self.real.label;
+}
+
+- (void)setLabel:value
+{
+  self.real.label = value;
+}
+
+- (id<MTLDevice>)device
+{
+  return id<MTLDevice>(self.wrappedCPP->GetObjCBridgeMTLDevice());
+}
+
+- (MTLCPUCacheMode)cpuCacheMode
+{
+  return self.real.cpuCacheMode;
+}
+
+- (MTLStorageMode)storageMode API_AVAILABLE(macos(10.11), ios(9.0))
+{
+  return self.real.storageMode;
+}
+
+- (MTLHazardTrackingMode)hazardTrackingMode API_AVAILABLE(macos(10.15), ios(13.0))
+{
+  return self.real.hazardTrackingMode;
+}
+
+- (MTLResourceOptions)resourceOptions API_AVAILABLE(macos(10.15), ios(13.0))
+{
+  return self.real.resourceOptions;
+}
+
+- (MTLPurgeableState)setPurgeableState:(MTLPurgeableState)state
+{
+  METAL_NOT_HOOKED();
+  return [self.real setPurgeableState:state];
+}
+
+- (id<MTLHeap>)heap API_AVAILABLE(macos(10.13), ios(10.0))
+{
+  return self.real.heap;
+}
+
+- (NSUInteger)heapOffset API_AVAILABLE(macos(10.15), ios(13.0))
+{
+  return self.real.heapOffset;
+}
+
+- (NSUInteger)allocatedSize API_AVAILABLE(macos(10.13), ios(11.0))
+{
+  return self.real.allocatedSize;
+}
+
+- (void)makeAliasable API_AVAILABLE(macos(10.13), ios(10.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real makeAliasable];
+}
+
+- (BOOL)isAliasable API_AVAILABLE(macos(10.13), ios(10.0))
+{
+  return [self.real isAliasable];
+}
+
+// MTLTexture : based on the protocol defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLTexture.h
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (id<MTLResource>)rootResource
+    API_DEPRECATED("Use parentTexture or buffer instead", macos(10.11, 10.12), ios(8.0, 10.0))
+{
+  return self.real.rootResource;
+}
+#pragma clang diagnostic pop
+
+- (id<MTLTexture>)parentTexture API_AVAILABLE(macos(10.11), ios(9.0))
+{
+  return self.real.parentTexture;
+}
+
+- (NSUInteger)parentRelativeLevel API_AVAILABLE(macos(10.11), ios(9.0))
+{
+  return self.real.parentRelativeLevel;
+}
+
+- (NSUInteger)parentRelativeSlice API_AVAILABLE(macos(10.11), ios(9.0))
+{
+  return self.real.parentRelativeSlice;
+}
+
+- (id<MTLBuffer>)buffer API_AVAILABLE(macos(10.12), ios(9.0))
+{
+  return self.real.buffer;
+}
+
+- (NSUInteger)bufferOffset API_AVAILABLE(macos(10.12), ios(9.0))
+{
+  return self.real.bufferOffset;
+}
+
+- (NSUInteger)bufferBytesPerRow API_AVAILABLE(macos(10.12), ios(9.0))
+{
+  return self.real.bufferBytesPerRow;
+}
+
+- (IOSurfaceRef)iosurface API_AVAILABLE(macos(10.11), ios(11.0))
+{
+  return self.real.iosurface;
+}
+
+- (NSUInteger)iosurfacePlane API_AVAILABLE(macos(10.11), ios(11.0))
+{
+  return self.real.iosurfacePlane;
+}
+
+- (MTLTextureType)textureType
+{
+  return self.real.textureType;
+}
+
+- (MTLPixelFormat)pixelFormat
+{
+  return self.real.pixelFormat;
+}
+
+- (NSUInteger)width
+{
+  return self.real.width;
+}
+
+- (NSUInteger)height
+{
+  return self.real.height;
+}
+
+- (NSUInteger)depth
+{
+  return self.real.depth;
+}
+
+- (NSUInteger)mipmapLevelCount
+{
+  return self.real.mipmapLevelCount;
+}
+
+- (NSUInteger)sampleCount
+{
+  return self.real.sampleCount;
+}
+
+- (NSUInteger)arrayLength
+{
+  return self.real.arrayLength;
+}
+
+- (MTLTextureUsage)usage
+{
+  return self.real.usage;
+}
+
+- (BOOL)isShareable API_AVAILABLE(macos(10.14), ios(13.0))
+{
+  return self.real.isShareable;
+}
+
+- (BOOL)isFramebufferOnly
+{
+  return self.real.isFramebufferOnly;
+}
+
+- (NSUInteger)firstMipmapInTail API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(13.0))
+{
+  return self.real.firstMipmapInTail;
+}
+
+- (NSUInteger)tailSizeInBytes API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(13.0))
+{
+  return self.real.tailSizeInBytes;
+}
+
+- (BOOL)isSparse API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(13.0))
+{
+  return self.real.isSparse;
+}
+
+- (BOOL)allowGPUOptimizedContents API_AVAILABLE(macos(10.14), ios(12.0))
+{
+  return self.real.allowGPUOptimizedContents;
+}
+
+- (void)getBytes:(void *)pixelBytes
+      bytesPerRow:(NSUInteger)bytesPerRow
+    bytesPerImage:(NSUInteger)bytesPerImage
+       fromRegion:(MTLRegion)region
+      mipmapLevel:(NSUInteger)level
+            slice:(NSUInteger)slice
+{
+  METAL_NOT_HOOKED();
+  [self.real getBytes:pixelBytes
+          bytesPerRow:bytesPerRow
+        bytesPerImage:bytesPerImage
+           fromRegion:region
+          mipmapLevel:level
+                slice:slice];
+}
+
+- (void)replaceRegion:(MTLRegion)region
+          mipmapLevel:(NSUInteger)level
+                slice:(NSUInteger)slice
+            withBytes:(const void *)pixelBytes
+          bytesPerRow:(NSUInteger)bytesPerRow
+        bytesPerImage:(NSUInteger)bytesPerImage
+{
+  METAL_NOT_HOOKED();
+  [self.real replaceRegion:region
+               mipmapLevel:level
+                     slice:slice
+                 withBytes:pixelBytes
+               bytesPerRow:bytesPerRow
+             bytesPerImage:bytesPerImage];
+}
+
+- (void)getBytes:(void *)pixelBytes
+     bytesPerRow:(NSUInteger)bytesPerRow
+      fromRegion:(MTLRegion)region
+     mipmapLevel:(NSUInteger)level
+{
+  METAL_NOT_HOOKED();
+  [self.real getBytes:pixelBytes bytesPerRow:bytesPerRow fromRegion:region mipmapLevel:level];
+}
+
+- (void)replaceRegion:(MTLRegion)region
+          mipmapLevel:(NSUInteger)level
+            withBytes:(const void *)pixelBytes
+          bytesPerRow:(NSUInteger)bytesPerRow
+{
+  METAL_NOT_HOOKED();
+  [self.real replaceRegion:region mipmapLevel:level withBytes:pixelBytes bytesPerRow:bytesPerRow];
+}
+
+- (nullable id<MTLTexture>)newTextureViewWithPixelFormat:(MTLPixelFormat)pixelFormat
+{
+  METAL_NOT_HOOKED();
+  return [self.real newTextureViewWithPixelFormat:pixelFormat];
+}
+
+- (nullable id<MTLTexture>)newTextureViewWithPixelFormat:(MTLPixelFormat)pixelFormat
+                                             textureType:(MTLTextureType)textureType
+                                                  levels:(NSRange)levelRange
+                                                  slices:(NSRange)sliceRange
+    API_AVAILABLE(macos(10.11), ios(9.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newTextureViewWithPixelFormat:pixelFormat
+                                      textureType:textureType
+                                           levels:levelRange
+                                           slices:sliceRange];
+}
+
+- (nullable MTLSharedTextureHandle *)newSharedTextureHandle API_AVAILABLE(macos(10.14), ios(13.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newSharedTextureHandle];
+}
+
+- (id<MTLTexture>)remoteStorageTexture API_AVAILABLE(macos(10.15))API_UNAVAILABLE(ios)
+{
+  METAL_NOT_HOOKED();
+  return [self.real remoteStorageTexture];
+}
+
+- (nullable id<MTLTexture>)newRemoteTextureViewForDevice:(id<MTLDevice>)device
+    API_AVAILABLE(macos(10.15))API_UNAVAILABLE(ios)
+{
+  METAL_NOT_HOOKED();
+  return [self.real newRemoteTextureViewForDevice:device];
+}
+
+- (MTLTextureSwizzleChannels)swizzle API_AVAILABLE(macos(10.15), ios(13.0))
+{
+  return self.real.swizzle;
+}
+
+- (nullable id<MTLTexture>)newTextureViewWithPixelFormat:(MTLPixelFormat)pixelFormat
+                                             textureType:(MTLTextureType)textureType
+                                                  levels:(NSRange)levelRange
+                                                  slices:(NSRange)sliceRange
+                                                 swizzle:(MTLTextureSwizzleChannels)swizzle
+    API_AVAILABLE(macos(10.15), ios(13.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newTextureViewWithPixelFormat:pixelFormat
+                                      textureType:textureType
+                                           levels:levelRange
+                                           slices:sliceRange
+                                          swizzle:swizzle];
+}
+
+@end

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -29,7 +29,9 @@
 #include "metal_function.h"
 #include "metal_library.h"
 #include "metal_manager.h"
+#include "metal_render_pipeline_state.h"
 #include "metal_resources.h"
+#include "metal_texture.h"
 
 RDCCOMPILE_ASSERT(sizeof(NS::Integer) == sizeof(std::intptr_t), "NS::Integer size does not match");
 RDCCOMPILE_ASSERT(sizeof(NS::UInteger) == sizeof(std::uintptr_t),
@@ -95,4 +97,114 @@ void DoSerialise(SerialiserType &ser, NS::String *&el)
   }
 }
 
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, MTL::TextureSwizzleChannels &el)
+{
+  SERIALISE_MEMBER(red);
+  SERIALISE_MEMBER(green);
+  SERIALISE_MEMBER(blue);
+  SERIALISE_MEMBER(alpha);
+}
+
+// MTLTextureDescriptor
+// {
+//   MTLTextureType textureType;
+//   MTLPixelFormat pixelFormat;
+//   NSUInteger width;
+//   NSUInteger height;
+//   NSUInteger depth;
+//   NSUInteger mipmapLevelCount;
+//   NSUInteger sampleCount;
+//   NSUInteger arrayLength;
+//   MTLResourceOptions resourceOptions;
+//   MTLCPUCacheMode cpuCacheMode
+//   MTLStorageMode storageMode
+//   MTLHazardTrackingMode hazardTrackingMode
+//   MTLTextureUsage usage
+//   BOOL allowGPUOptimizedContents
+//   MTLTextureSwizzleChannels swizzle
+// }
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, MTL::TextureDescriptor *&el)
+{
+  MTL::TextureType textureType;
+  MTL::PixelFormat pixelFormat;
+  NS::UInteger width;
+  NS::UInteger height;
+  NS::UInteger depth;
+  NS::UInteger mipmapLevelCount;
+  NS::UInteger sampleCount;
+  NS::UInteger arrayLength;
+  MTL::ResourceOptions resourceOptions;
+  MTL::CPUCacheMode cpuCacheMode;
+  MTL::StorageMode storageMode;
+  MTL::HazardTrackingMode hazardTrackingMode;
+  MTL::TextureUsage usage;
+  bool allowGPUOptimizedContents;
+  MTL::TextureSwizzleChannels swizzle;
+
+  if(ser.IsWriting())
+  {
+    textureType = el->textureType();
+    pixelFormat = el->pixelFormat();
+    width = el->width();
+    height = el->height();
+    depth = el->depth();
+    mipmapLevelCount = el->mipmapLevelCount();
+    sampleCount = el->sampleCount();
+    arrayLength = el->arrayLength();
+    resourceOptions = el->resourceOptions();
+    cpuCacheMode = el->cpuCacheMode();
+    storageMode = el->storageMode();
+    hazardTrackingMode = el->hazardTrackingMode();
+    usage = el->usage();
+    allowGPUOptimizedContents = el->allowGPUOptimizedContents();
+    swizzle = el->swizzle();
+  }
+
+  SERIALISE_ELEMENT(textureType);
+  SERIALISE_ELEMENT(pixelFormat);
+  SERIALISE_ELEMENT(width);
+  SERIALISE_ELEMENT(height);
+  SERIALISE_ELEMENT(depth);
+  SERIALISE_ELEMENT(mipmapLevelCount);
+  SERIALISE_ELEMENT(sampleCount);
+  SERIALISE_ELEMENT(arrayLength);
+  SERIALISE_ELEMENT(resourceOptions);
+  SERIALISE_ELEMENT(cpuCacheMode);
+  SERIALISE_ELEMENT(storageMode);
+  SERIALISE_ELEMENT(hazardTrackingMode);
+  SERIALISE_ELEMENT(usage);
+  SERIALISE_ELEMENT(allowGPUOptimizedContents);
+  SERIALISE_ELEMENT(swizzle);
+
+  if(ser.IsReading())
+  {
+    MetalResourceManager *rm = (MetalResourceManager *)ser.GetUserData();
+    if(rm && IsReplayMode(rm->GetState()))
+    {
+      RDCASSERT(el == NULL);
+      el = MTL::TextureDescriptor::alloc();
+      el->setTextureType(textureType);
+      el->setPixelFormat(pixelFormat);
+      el->setWidth(width);
+      el->setHeight(height);
+      el->setDepth(depth);
+      el->setMipmapLevelCount(mipmapLevelCount);
+      el->setSampleCount(sampleCount);
+      el->setArrayLength(arrayLength);
+      el->setResourceOptions(resourceOptions);
+      el->setCpuCacheMode(cpuCacheMode);
+      el->setStorageMode(storageMode);
+      el->setHazardTrackingMode(hazardTrackingMode);
+      el->setUsage(usage);
+      el->setAllowGPUOptimizedContents(allowGPUOptimizedContents);
+      el->setSwizzle(swizzle);
+    }
+  }
+}
+
+INSTANTIATE_SERIALISE_TYPE(MTL::TextureDescriptor *);
 INSTANTIATE_SERIALISE_TYPE(NS::String *);
+INSTANTIATE_SERIALISE_TYPE(MTL::TextureSwizzleChannels);

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -28,12 +28,17 @@
 #include "official/metal-cpp.h"
 #include "serialise/serialiser.h"
 
+// TODO: use Metal Feature sets to determine this value at capture time
+const uint32_t MAX_RENDER_PASS_COLOR_ATTACHMENTS = 8;
+
 #define METALCPP_WRAPPED_PROTOCOLS(FUNC) \
   FUNC(CommandBuffer);                   \
   FUNC(CommandQueue);                    \
   FUNC(Device);                          \
   FUNC(Function);                        \
-  FUNC(Library);
+  FUNC(Library);                         \
+  FUNC(RenderPipelineState);             \
+  FUNC(Texture);
 
 // These serialise overloads will fetch the ID during capture, serialise the ID
 // directly as-if it were the original type, then on replay load up the resource if available.
@@ -61,6 +66,47 @@ METALCPP_WRAPPED_PROTOCOLS(DECLARE_WRAPPED_TYPE_SERIALISE);
 METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)
 #undef DECLARE_OBJC_HELPERS
 
+#define MTL_DECLARE_REFLECTION_OBJECT(TYPE)      \
+  template <>                                    \
+  inline rdcliteral TypeName<MTL::TYPE *>()      \
+  {                                              \
+    return STRING_LITERAL(STRINGIZE(MTL##TYPE)); \
+  }                                              \
+  template <class SerialiserType>                \
+  void DoSerialise(SerialiserType &ser, MTL::TYPE *&el);
+
+#define MTL_DECLARE_REFLECTION_TYPE(TYPE)        \
+  template <>                                    \
+  inline rdcliteral TypeName<MTL::TYPE>()        \
+  {                                              \
+    return STRING_LITERAL(STRINGIZE(MTL##TYPE)); \
+  }                                              \
+  template <class SerialiserType>                \
+  void DoSerialise(SerialiserType &ser, MTL::TYPE &el);
+
+MTL_DECLARE_REFLECTION_OBJECT(TextureDescriptor)
+MTL_DECLARE_REFLECTION_OBJECT(RenderPipelineDescriptor);
+MTL_DECLARE_REFLECTION_OBJECT(RenderPipelineColorAttachmentDescriptor);
+
+MTL_DECLARE_REFLECTION_TYPE(PixelFormat);
+MTL_DECLARE_REFLECTION_TYPE(TextureType);
+MTL_DECLARE_REFLECTION_TYPE(PrimitiveTopologyClass);
+MTL_DECLARE_REFLECTION_TYPE(ResourceOptions);
+MTL_DECLARE_REFLECTION_TYPE(CPUCacheMode);
+MTL_DECLARE_REFLECTION_TYPE(StorageMode);
+MTL_DECLARE_REFLECTION_TYPE(HazardTrackingMode);
+MTL_DECLARE_REFLECTION_TYPE(TextureUsage);
+MTL_DECLARE_REFLECTION_TYPE(TextureSwizzleChannels);
+MTL_DECLARE_REFLECTION_TYPE(TextureSwizzle);
+MTL_DECLARE_REFLECTION_TYPE(ColorWriteMask);
+MTL_DECLARE_REFLECTION_TYPE(BlendOperation);
+MTL_DECLARE_REFLECTION_TYPE(BlendFactor);
+MTL_DECLARE_REFLECTION_TYPE(Winding);
+MTL_DECLARE_REFLECTION_TYPE(TessellationFactorFormat);
+MTL_DECLARE_REFLECTION_TYPE(TessellationControlPointIndexType)
+MTL_DECLARE_REFLECTION_TYPE(TessellationFactorStepFunction);
+MTL_DECLARE_REFLECTION_TYPE(TessellationPartitionMode);
+
 template <>
 inline rdcliteral TypeName<NS::String *>()
 {
@@ -68,3 +114,5 @@ inline rdcliteral TypeName<NS::String *>()
 }
 template <class SerialiserType>
 void DoSerialise(SerialiserType &ser, NS::String *&el);
+
+void MTLFixupForMetalDriverAssert();

--- a/renderdoc/driver/metal/metal_types_bridge.mm
+++ b/renderdoc/driver/metal/metal_types_bridge.mm
@@ -28,6 +28,8 @@
 #include "metal_device.h"
 #include "metal_function.h"
 #include "metal_library.h"
+#include "metal_render_pipeline_state.h"
+#include "metal_texture.h"
 
 #define DEFINE_OBJC_HELPERS(CPPTYPE)                                               \
   static ObjCBridgeMTL##CPPTYPE *GetObjCBridge(MTL::CPPTYPE *cppType)              \
@@ -85,3 +87,18 @@
 
 METALCPP_WRAPPED_PROTOCOLS(DEFINE_OBJC_HELPERS)
 #undef DEFINE_OBJC_HELPERS
+
+static bool s_fixupMetalDriverAssert = false;
+
+void MTLFixupForMetalDriverAssert()
+{
+  if(s_fixupMetalDriverAssert)
+    return;
+
+#if ENABLED(RDOC_DEVEL)
+  NSLog(@"Fixup for Metal Driver debug assert. Adding protocol `MTLTextureImplementation` to "
+        @"`ObjCBridgeMTLTexture`");
+  class_addProtocol([ObjCBridgeMTLTexture class], objc_getProtocol("MTLTextureImplementation"));
+#endif
+  s_fixupMetalDriverAssert = true;
+}


### PR DESCRIPTION
## Description

Added wrapped MTLRenderPipelineState & MTLTexture.

Implemented capture serialisation for APIs:
`MTLDevice::newRenderPipelineStateWithDescriptor`
`MTLDevice::newTextureWithDescriptor`: two versions, which use a shared helper method to avoid code duplication. They also share the same serialization code but with a different chunk value and string name.

Workaround to prevent Metal capture library assert triggering on the bridge `MTLTexture` object, add protocol `MTLTextureImplementation` to class `ObjCBridgeMTLTexture`

Serialisation for helper types:
`MTL::TextureDescriptor`
`MTL::RenderPipelineDescriptor` : serialisation of some more complex members has been left as TODOs
`MTL::RenderPipelineColorAttachmentDescriptor`
`MTL::PixelFormat`
`MTL::TextureType`
`MTL::PrimitiveTopologyClass`
`MTL::ResourceOptions`
`MTL::CPUCacheMode`
`MTL::StorageMode`
`MTL::HazardTrackingMode`
`MTL::TextureUsage`
`MTL::TextureSwizzleChannels`
`MTL::TextureSwizzle`
`MTL::ColorWriteMask`
`MTL::BlendOperation`
`MTL::BlendFactor`
`MTL::Winding`
`MTL::TessellationFactorFormat`
`MTL::TessellationControlPointIndexType`
`MTL::TessellationFactorStepFunction`
`MTL::TessellationPartitionMode`

### Record and Chunks
- When creating `MTLRenderPIpelineState` any `MTLFunction` references in the descriptor have their parent set to be the `MTLRenderPIpelineState` resource record.