### PR TITLE
Draft: Metal basic capture

### DIFF
--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -195,6 +195,7 @@ rdcstr DoStringise(const RDCDriver &el)
     STRINGISE_ENUM_CLASS(D3D8);
     STRINGISE_ENUM_CLASS(Image);
     STRINGISE_ENUM_CLASS(Vulkan);
+    STRINGISE_ENUM_CLASS(Metal);
   }
   END_ENUM_STRINGISE();
 }

--- a/renderdoc/core/core.h
+++ b/renderdoc/core/core.h
@@ -219,6 +219,7 @@ enum class RDCDriver : uint32_t
   Vulkan = 8,
   OpenGLES = 9,
   D3D8 = 10,
+  Metal = 11,
   MaxBuiltin,
   Custom = 100000,
   Custom0 = Custom,

--- a/renderdoc/driver/metal/metal_buffer.cpp
+++ b/renderdoc/driver/metal/metal_buffer.cpp
@@ -100,8 +100,7 @@ void WrappedMTLBuffer::didModifyRange(NS::Range &range)
         Serialise_didModifyRange(ser, range);
         chunk = scope.Get();
       }
-      // TODO: add to the frame capture record chunk
-      // m_Device->AddFrameCaptureRecordChunk(chunk);
+      m_Device->AddFrameCaptureRecordChunk(chunk);
     }
   }
   else

--- a/renderdoc/driver/metal/metal_core.h
+++ b/renderdoc/driver/metal/metal_core.h
@@ -28,8 +28,53 @@
 
 struct MetalInitParams
 {
+  MetalInitParams();
+  void Set(MTL::Device *pDevice, ResourceId inst);
+
+  // update this when adding/removing members
+  uint64_t GetSerialiseSize();
+
   // check if a frame capture section version is supported
   static const uint64_t CurrentVersion = 0x1;
+
+  // device information
+  NS::String *name;
+  uint64_t recommendedMaxWorkingSetSize;
+  uint64_t maxTransferRate;
+  uint64_t registryID;
+  uint64_t peerGroupID;
+  uint32_t peerCount;
+  uint32_t peerIndex;
+  MTL::DeviceLocation location;
+  NS::UInteger locationNumber;
+  bool hasUnifiedMemory;
+  bool headless;
+  bool lowPower;
+  bool removable;
+
+  // device capabilities
+  bool supportsMTLGPUFamilyCommon1;
+  bool supportsMTLGPUFamilyCommon2;
+  bool supportsMTLGPUFamilyCommon3;
+
+  bool supportsMTLGPUFamilyApple1;
+  bool supportsMTLGPUFamilyApple2;
+  bool supportsMTLGPUFamilyApple3;
+  bool supportsMTLGPUFamilyApple4;
+  bool supportsMTLGPUFamilyApple5;
+  bool supportsMTLGPUFamilyApple6;
+  bool supportsMTLGPUFamilyApple7;
+  bool supportsMTLGPUFamilyApple8;
+
+  bool supportsMTLGPUFamilyMac1;
+  bool supportsMTLGPUFamilyMac2;
+
+  bool supportsMTLGPUFamilyMacCatalyst1;
+  bool supportsMTLGPUFamilyMacCatalyst2;
+
+  MTL::ArgumentBuffersTier argumentBuffersSupport;
+
+  ResourceId InstanceID;
 };
 
 DECLARE_REFLECTION_STRUCT(MetalInitParams);

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -37,6 +37,7 @@ WrappedMTLDevice::WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId)
 {
   AllocateObjCBridge(this);
   m_Device = this;
+  m_Capturer = new MetalCapturer(this);
 
   if(RenderDoc::Inst().IsReplayApp())
   {
@@ -46,21 +47,55 @@ WrappedMTLDevice::WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId)
     m_State = CaptureState::BackgroundCapturing;
   }
 
+  m_SectionVersion = MetalInitParams::CurrentVersion;
+
   threadSerialiserTLSSlot = Threading::AllocateTLSSlot();
 
   m_ResourceManager = new MetalResourceManager(m_State, this);
+
+  m_HeaderChunk = NULL;
+
+  if(!RenderDoc::Inst().IsReplayApp())
+  {
+    m_FrameCaptureRecord = GetResourceManager()->AddResourceRecord(ResourceIDGen::GetNewUniqueID());
+    m_FrameCaptureRecord->DataInSerialiser = false;
+    m_FrameCaptureRecord->Length = 0;
+    m_FrameCaptureRecord->InternalResource = true;
+  }
+  else
+  {
+    m_FrameCaptureRecord = NULL;
+
+    ResourceIDGen::SetReplayResourceIDs();
+  }
+
   RDCASSERT(m_Device == this);
   GetResourceManager()->AddCurrentResource(objId, this);
-}
 
-WrappedMTLDevice *WrappedMTLDevice::MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice)
-{
-  MTLFixupForMetalDriverAssert();
-  MTLHookObjcMethods();
-  ResourceId objId = ResourceIDGen::GetNewUniqueID();
-  WrappedMTLDevice *wrappedMTLDevice = new WrappedMTLDevice(realMTLDevice, objId);
+  if(IsCaptureMode(m_State))
+  {
+    Chunk *chunk = NULL;
 
-  return wrappedMTLDevice;
+    {
+      CACHE_THREAD_SERIALISER();
+
+      SCOPED_SERIALISE_CHUNK(MetalChunk::MTLCreateSystemDefaultDevice);
+      Serialise_MTLCreateSystemDefaultDevice(ser);
+      chunk = scope.Get();
+    }
+
+    MetalResourceRecord *record = GetResourceManager()->AddResourceRecord(this);
+    record->AddChunk(chunk);
+  }
+  else
+  {
+    // TODO: implement RD MTL replay
+  }
+
+  RenderDoc::Inst().AddDeviceFrameCapturer(this, m_Capturer);
+
+  m_mtlCommandQueue = Unwrap(this)->newCommandQueue();
+  FirstFrame();
 }
 
 IMP WrappedMTLDevice::g_real_CAMetalLayer_nextDrawable;
@@ -107,6 +142,30 @@ void WrappedMTLDevice::MTLFixupForMetalDriverAssert()
 }
 
 // Serialised MTLDevice APIs
+
+template <typename SerialiserType>
+bool WrappedMTLDevice::Serialise_MTLCreateSystemDefaultDevice(SerialiserType &ser)
+{
+  SERIALISE_ELEMENT_LOCAL(Device, GetResID(this)).TypedAs("MTLDevice"_lit);
+
+  SERIALISE_CHECK_READ_ERRORS();
+
+  if(IsReplayingAndReading())
+  {
+    // TODO: implement RD MTL replay
+  }
+  return true;
+}
+
+WrappedMTLDevice *WrappedMTLDevice::MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice)
+{
+  MTLFixupForMetalDriverAssert();
+  MTLHookObjcMethods();
+  ResourceId objId = ResourceIDGen::GetNewUniqueID();
+  WrappedMTLDevice *wrappedMTLDevice = new WrappedMTLDevice(realMTLDevice, objId);
+
+  return wrappedMTLDevice;
+}
 
 template <typename SerialiserType>
 bool WrappedMTLDevice::Serialise_newCommandQueue(SerialiserType &ser, WrappedMTLCommandQueue *queue)
@@ -539,8 +598,8 @@ WrappedMTLTexture *WrappedMTLDevice::Common_NewTexture(RDMTL::TextureDescriptor 
     if(IsCaptureMode(m_State))
     {
       {
-        SCOPED_LOCK(m_PotentialBackBuffersLock);
-        m_PotentialBackBuffers.insert(wrappedMTLTexture);
+        SCOPED_LOCK(m_CapturePotentialBackBuffersLock);
+        m_CapturePotentialBackBuffers.insert(wrappedMTLTexture);
       }
     }
   }
@@ -578,6 +637,7 @@ WrappedMTLBuffer *WrappedMTLDevice::Common_NewBuffer(bool withBytes, const void 
   return wrappedMTLBuffer;
 }
 
+INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLDevice, bool, MTLCreateSystemDefaultDevice);
 INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLDevice, WrappedMTLCommandQueue *,
                                             newCommandQueue);
 INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLDevice, WrappedMTLLibrary *, newDefaultLibrary);

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -25,15 +25,18 @@
 #pragma once
 
 #include "metal_common.h"
+#include "metal_core.h"
 #include "metal_manager.h"
+
+class MetalCapturer;
 
 class WrappedMTLDevice : public WrappedMTLObject
 {
-  friend class MetalResourceManager;
-
 public:
   WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId);
   ~WrappedMTLDevice() {}
+  template <typename SerialiserType>
+  bool Serialise_MTLCreateSystemDefaultDevice(SerialiserType &ser);
   static WrappedMTLDevice *MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice);
 
   // Serialised MTLDevice APIs
@@ -85,7 +88,29 @@ public:
   CaptureState &GetStateRef() { return m_State; }
   CaptureState GetState() { return m_State; }
   MetalResourceManager *GetResourceManager() { return m_ResourceManager; };
+  void WaitForGPU();
   WriteSerialiser &GetThreadSerialiser();
+
+  // IFrameCapturer interface
+  RDCDriver GetFrameCaptureDriver() { return RDCDriver::Metal; }
+  void StartFrameCapture(DeviceOwnedWindow devWnd);
+  bool EndFrameCapture(DeviceOwnedWindow devWnd);
+  bool DiscardFrameCapture(DeviceOwnedWindow devWnd);
+  // IFrameCapturer interface
+
+  void CaptureCmdBufCommit(MetalResourceRecord *record);
+  void CaptureCmdBufEnqueue(MetalResourceRecord *record);
+
+  void AddFrameCaptureRecordChunk(Chunk *chunk) { m_FrameCaptureRecord->AddChunk(chunk); }
+  // From ResourceManager interface
+  bool Prepare_InitialState(WrappedMTLObject *res);
+  uint64_t GetSize_InitialState(ResourceId id, const MetalInitialContents &initial);
+  template <typename SerialiserType>
+  bool Serialise_InitialState(SerialiserType &ser, ResourceId id, MetalResourceRecord *record,
+                              const MetalInitialContents *initial);
+  void Create_InitialState(ResourceId id, WrappedMTLObject *live, bool hasData);
+  void Apply_InitialState(WrappedMTLObject *live, const MetalInitialContents &initial);
+  // From ResourceManager interface
 
   enum
   {
@@ -98,13 +123,18 @@ public:
 private:
   static void MTLFixupForMetalDriverAssert();
   static void MTLHookObjcMethods();
-  bool Prepare_InitialState(WrappedMTLObject *res);
-  uint64_t GetSize_InitialState(ResourceId id, const MetalInitialContents &initial);
+  void FirstFrame();
+  void AdvanceFrame();
+  void Present(MetalResourceRecord *record);
+
+  void CaptureClearSubmittedCmdBuffers();
+  void CaptureCmdBufSubmit(MetalResourceRecord *record);
+  void EndCaptureFrame();
+
   template <typename SerialiserType>
-  bool Serialise_InitialState(SerialiserType &ser, ResourceId id, MetalResourceRecord *record,
-                              const MetalInitialContents *initial);
-  void Create_InitialState(ResourceId id, WrappedMTLObject *live, bool hasData);
-  void Apply_InitialState(WrappedMTLObject *live, const MetalInitialContents &initial);
+  bool Serialise_CaptureScope(SerialiserType &ser);
+  template <typename SerialiserType>
+  bool Serialise_BeginCaptureFrame(SerialiserType &ser);
 
   WrappedMTLTexture *Common_NewTexture(RDMTL::TextureDescriptor &descriptor, MetalChunk chunkType,
                                        bool ioSurfaceTexture, IOSurfaceRef iosurface,
@@ -112,15 +142,56 @@ private:
   WrappedMTLBuffer *Common_NewBuffer(bool withBytes, const void *pointer, NS::UInteger length,
                                      MTL::ResourceOptions options);
 
-  MetalResourceManager *m_ResourceManager;
+  MetalResourceManager *m_ResourceManager = NULL;
 
   // Back buffer and swap chain emulation
-  Threading::CriticalSection m_PotentialBackBuffersLock;
-  std::unordered_set<WrappedMTLTexture *> m_PotentialBackBuffers;
+  Threading::CriticalSection m_CapturePotentialBackBuffersLock;
+  std::unordered_set<WrappedMTLTexture *> m_CapturePotentialBackBuffers;
+  Threading::CriticalSection m_CaptureOutputLayersLock;
+  std::unordered_set<CA::MetalLayer *> m_CaptureOutputLayers;
 
   CaptureState m_State;
+  bool m_AppControlledCapture = false;
 
   uint64_t threadSerialiserTLSSlot;
   Threading::CriticalSection m_ThreadSerialisersLock;
   rdcarray<WriteSerialiser *> m_ThreadSerialisers;
+  uint64_t m_SectionVersion = 0;
+
+  MetalCapturer *m_Capturer = NULL;
+  uint32_t m_FrameCounter = 0;
+  rdcarray<FrameDescription> m_CapturedFrames;
+  Threading::RWLock m_CapTransitionLock;
+  MetalResourceRecord *m_FrameCaptureRecord = NULL;
+  Chunk *m_HeaderChunk = NULL;
+
+  // record the command buffer records to insert them individually
+  // (even if they were recorded locklessly in parallel)
+  // queue submit order will enforce/display ordering, record order is not important
+  Threading::CriticalSection m_CaptureCommandBuffersLock;
+  rdcarray<MetalResourceRecord *> m_CaptureCommandBuffersEnqueued;
+  rdcarray<MetalResourceRecord *> m_CaptureCommandBuffersSubmitted;
+
+  PerformanceTimer m_CaptureTimer;
+  MetalInitParams m_InitParams;
+
+  MTL::CommandQueue *m_mtlCommandQueue = NULL;
+};
+
+class MetalCapturer : public IFrameCapturer
+{
+public:
+  MetalCapturer(WrappedMTLDevice *device) : m_Device(device) {}
+  // IFrameCapturer interface
+  RDCDriver GetFrameCaptureDriver() { return RDCDriver::Metal; }
+  void StartFrameCapture(DeviceOwnedWindow devWnd) { return m_Device->StartFrameCapture(devWnd); }
+  bool EndFrameCapture(DeviceOwnedWindow devWnd) { return m_Device->EndFrameCapture(devWnd); }
+  bool DiscardFrameCapture(DeviceOwnedWindow devWnd)
+  {
+    return m_Device->DiscardFrameCapture(devWnd);
+  }
+  // IFrameCapturer interface
+
+private:
+  WrappedMTLDevice *m_Device = NULL;
 };

--- a/renderdoc/driver/metal/metal_init_state.cpp
+++ b/renderdoc/driver/metal/metal_init_state.cpp
@@ -62,9 +62,5 @@ void WrappedMTLDevice::Apply_InitialState(WrappedMTLObject *live, const MetalIni
   METAL_NOT_IMPLEMENTED();
 }
 
-template bool WrappedMTLDevice::Serialise_InitialState(ReadSerialiser &ser, ResourceId id,
-                                                       MetalResourceRecord *record,
-                                                       const MetalInitialContents *initial);
-template bool WrappedMTLDevice::Serialise_InitialState(WriteSerialiser &ser, ResourceId id,
-                                                       MetalResourceRecord *record,
-                                                       const MetalInitialContents *initial);
+INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLDevice, void, InitialState, ResourceId id,
+                                MetalResourceRecord *record, const MetalInitialContents *initial);

--- a/renderdoccmd/renderdoccmd_apple.cpp
+++ b/renderdoccmd/renderdoccmd_apple.cpp
@@ -113,6 +113,11 @@ int main(int argc, char *argv[])
     count++;
 #endif
 
+#if defined(RENDERDOC_SUPPORT_METAL)
+    support += "Metal, ";
+    count++;
+#endif
+
     if(count == 0)
     {
       support += "None.";


### PR DESCRIPTION
## Description

Captures can be manually triggered from `renderdoccmd capture <application>` using F12 or from the UI on the in-development Metal replay branch.
The captures can be loaded and replayed on the in-development Metal replay branch.

The command buffer tracking and serialization are done by GPU submission order which is not necessarily the same as CPU commit order. The command buffer tracking for GPU submission order is currently using an `rdcarray`, this might change in the future to use a linked list if the performance of appending and deleting from the `rdcarray` becomes a performance bottleneck.

Does not include support for the presented `MTLDrawable` ie.
* Thumbnail generation of the final presented image.
* Serializing the presented texture ID.

Does not include support for initial state data.
* No `MTLBuffer` data contents are serialized.

There is a lot missing and a lot of TODOs. 
This is the basic structure for capturing which is then built upon. 
Future PRs will include support for the presented `MTLDrawable` and initial state data for `MTLBuffer` contents.

### Includes:
* register the Metal device as a frame capturer ie. `AddDeviceFrameCapturer`
* logic for triggering captures at `Present` ie. `AddActiveDriver`, `StartFrameCapture`, `EndFrameCapture`.
* Stopped declaring `MetalResourceManager` as a friend of `WrappedMTLDevice` which meant making the initial state-related APIs `public` instead of `private`.
* `IFrameCapturer` interface APIs
* Command buffer tracking for including in the output capture `CaptureCmdBufCommit` and `CaptureCmdBufEnqueue`.
* `Serialise_MTLCreateSystemDefaultDevice(SerialiserType &ser)`
* A helper class `MetalCapturer` which is derived from `IFrameCapturer` and registered with the RenderDoc instance. This is because Wrapped Metal classes can't have virtual tables as a requirement for how the C++ and Objective C overlay is implemented.
* The frame capture chunk and API `AddFrameCaptureRecordChunk()`
* `MetalInitParams` data and serialization.

### Helper Methods and Members in `MTLDevice`
* `WaitForGPU()`
* `MTL::CommandQueue *m_mtlCommandQueue` which is used to implement `WaitForGPU()`
* `CaptureClearSubmittedCmdBuffers()` & `CaptureCmdBufSubmit()`

### Details on the memory lifetime for `WrappedMTLCommandBuffer`
* retain/release the real resource during the scope of `WrappedMTLCommandBuffer::commit()`

During capture (Background or Active)
* `AddRef()` record when command buffer is enqueued (explicit or implicit)
* `Delete()` record at end of command buffer submit

During Active capture
* `AddRef()` record in command buffer submit
* `Delete()` submitted command buffers as part of finalizing the capture
