### PR TITLE
Apple support for Output_DebugMon

### DIFF
--- a/renderdoc/os/posix/apple/apple_process.cpp
+++ b/renderdoc/os/posix/apple/apple_process.cpp
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include "common/common.h"
 #include "common/formatting.h"
+#include "core/core.h"
 #include "os/os_specific.h"
 
 char **GetCurrentEnvironment()
@@ -199,4 +200,11 @@ uint64_t Process::GetMemoryUsage()
     return 0;
 
   return taskInfo.resident_size;
+}
+
+// Helper method to avoid #include file conflicts between
+// <Carbon/Carbon.h> and "core/core.h"
+bool ShouldOutputDebugMon()
+{
+  return OSUtility::DebuggerPresent() && RenderDoc::Inst().IsReplayApp();
 }

--- a/renderdoc/os/posix/apple/apple_stringio.cpp
+++ b/renderdoc/os/posix/apple/apple_stringio.cpp
@@ -318,6 +318,10 @@ rdcwstr UTF82Wide(const rdcstr &s)
 }
 };
 
+// Helper method to avoid #include file conflicts between
+// <Carbon/Carbon.h> and "core/core.h"
+bool ShouldOutputDebugMon();
+
 namespace OSUtility
 {
 void WriteOutput(int channel, const char *str)
@@ -326,6 +330,8 @@ void WriteOutput(int channel, const char *str)
     fprintf(stdout, "%s", str);
   else if(channel == OSUtility::Output_StdErr)
     fprintf(stderr, "%s", str);
+  else if(channel == OSUtility::Output_DebugMon && ShouldOutputDebugMon())
+    fprintf(stdout, "%s", str);
 }
 
 uint64_t GetMachineIdent()


### PR DESCRIPTION
## Description

Display RD logs in the Xcode console window for Debug builds.
On Apple cache, the debugger is attached result to save CPU cycles.

## Testing

Ran Debug/Release builds of qrenderdoc and renderdoccmd in Xcode and from a terminal
RD logs only showed in the Xcode console for the Debug builds.
RD logs did not get displayed to the terminal output.