### PR TITLE
Small follow up fixes and tweaks to Metal support

### DIFF
--- a/renderdoc/driver/metal/metal_command_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_command_buffer_bridge.mm
@@ -123,7 +123,7 @@
 - (void)enqueue
 {
   METAL_NOT_HOOKED();
-  [self enqueue];
+  [self.real enqueue];
 }
 
 - (void)commit

--- a/renderdoc/driver/metal/metal_common.h
+++ b/renderdoc/driver/metal/metal_common.h
@@ -162,10 +162,10 @@ DECLARE_REFLECTION_ENUM(MetalChunk);
 #define IsReplayingAndReading() (ser.IsReading() && IsReplayMode(m_Device->GetState()))
 
 #ifdef __OBJC__
-#define METAL_NOT_HOOKED()                                                             \
-  do                                                                                   \
-  {                                                                                    \
-    RDCWARN("Metal %s %s not hooked", class_getName([self class]), sel_getName(_cmd)); \
+#define METAL_NOT_HOOKED()                                                          \
+  do                                                                                \
+  {                                                                                 \
+    RDCERR("Metal %s %s not hooked", object_getClassName(self), sel_getName(_cmd)); \
   } while((void)0, 0)
 #endif
 
@@ -178,11 +178,11 @@ DECLARE_REFLECTION_ENUM(MetalChunk);
 
 // similar to RDCUNIMPLEMENTED but for things that are hit often so we don't want to fire the
 // debugbreak.
-#define METAL_NOT_IMPLEMENTED_ONCE(...)                                           \
-  do                                                                              \
-  {                                                                               \
-    static bool msgprinted = false;                                               \
-    if(!msgprinted)                                                               \
-      RDCDEBUG("Metal '%s' not implemented - " __VA_ARGS__, __PRETTY_FUNCTION__); \
-    msgprinted = true;                                                            \
+#define METAL_NOT_IMPLEMENTED_ONCE(...)                                          \
+  do                                                                             \
+  {                                                                              \
+    static bool msgprinted = false;                                              \
+    if(!msgprinted)                                                              \
+      RDCWARN("Metal '%s' not implemented - " __VA_ARGS__, __PRETTY_FUNCTION__); \
+    msgprinted = true;                                                           \
   } while((void)0, 0)

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -42,18 +42,13 @@ public:
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLLibrary *, newLibraryWithSource,
                                           NS::String *source, MTL::CompileOptions *options,
                                           NS::Error **error);
-  WrappedMTLRenderPipelineState *newRenderPipelineStateWithDescriptor(
-      MTL::RenderPipelineDescriptor *descriptor, NS::Error **error);
-  template <typename SerialiserType>
-  bool Serialise_newRenderPipelineStateWithDescriptor(SerialiserType &ser,
-                                                      WrappedMTLRenderPipelineState *,
-                                                      RDMTL::RenderPipelineDescriptor &descriptor,
-                                                      NS::Error **error);
-  WrappedMTLTexture *newTextureWithDescriptor(MTL::TextureDescriptor *descriptor,
+  DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLRenderPipelineState *,
+                                          newRenderPipelineStateWithDescriptor,
+                                          RDMTL::RenderPipelineDescriptor &descriptor,
+                                          NS::Error **error);
+  WrappedMTLTexture *newTextureWithDescriptor(RDMTL::TextureDescriptor &descriptor,
                                               IOSurfaceRef iosurface, NS::UInteger plane);
-  WrappedMTLTexture *newTextureWithDescriptor(MTL::TextureDescriptor *descriptor);
-  template <typename SerialiserType>
-  bool Serialise_newTextureWithDescriptor(SerialiserType &ser, WrappedMTLTexture *,
+  DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLTexture *, newTextureWithDescriptor,
                                           RDMTL::TextureDescriptor &descriptor);
 
   // Non-Serialised MTLDevice APIs
@@ -108,7 +103,7 @@ private:
   void Create_InitialState(ResourceId id, WrappedMTLObject *live, bool hasData);
   void Apply_InitialState(WrappedMTLObject *live, const MetalInitialContents &initial);
 
-  WrappedMTLTexture *Common_NewTexture(MTL::TextureDescriptor *descriptor, MetalChunk chunkType,
+  WrappedMTLTexture *Common_NewTexture(RDMTL::TextureDescriptor &descriptor, MetalChunk chunkType,
                                        bool ioSurfaceTexture, IOSurfaceRef iosurface,
                                        NS::UInteger plane);
 

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -257,8 +257,8 @@
 
 - (nullable id<MTLTexture>)newTextureWithDescriptor:(MTLTextureDescriptor *)descriptor
 {
-  return id<MTLTexture>(
-      GetWrapped(self)->newTextureWithDescriptor((MTL::TextureDescriptor *)descriptor));
+  RDMTL::TextureDescriptor rdDescriptor((MTL::TextureDescriptor *)descriptor);
+  return id<MTLTexture>(GetWrapped(self)->newTextureWithDescriptor(rdDescriptor));
 }
 
 - (nullable id<MTLTexture>)newTextureWithDescriptor:(MTLTextureDescriptor *)descriptor
@@ -266,8 +266,8 @@
                                               plane:(NSUInteger)plane
     API_AVAILABLE(macos(10.11), ios(11.0))
 {
-  return id<MTLTexture>(GetWrapped(self)->newTextureWithDescriptor(
-      (MTL::TextureDescriptor *)descriptor, iosurface, plane));
+  RDMTL::TextureDescriptor rdDescriptor((MTL::TextureDescriptor *)descriptor);
+  return id<MTLTexture>(GetWrapped(self)->newTextureWithDescriptor(rdDescriptor, iosurface, plane));
 }
 
 - (nullable id<MTLTexture>)newSharedTextureWithDescriptor:(MTLTextureDescriptor *)descriptor
@@ -366,8 +366,9 @@
 newRenderPipelineStateWithDescriptor:(MTLRenderPipelineDescriptor *)descriptor
                                error:(__autoreleasing NSError **)error
 {
-  return id<MTLRenderPipelineState>(GetWrapped(self)->newRenderPipelineStateWithDescriptor(
-      (MTL::RenderPipelineDescriptor *)descriptor, (NS::Error **)error));
+  RDMTL::RenderPipelineDescriptor rdDescriptor((MTL::RenderPipelineDescriptor *)descriptor);
+  return id<MTLRenderPipelineState>(
+      GetWrapped(self)->newRenderPipelineStateWithDescriptor(rdDescriptor, (NS::Error **)error));
 }
 
 - (nullable id<MTLRenderPipelineState>)

--- a/renderdoc/driver/metal/metal_serialise.cpp
+++ b/renderdoc/driver/metal/metal_serialise.cpp
@@ -166,7 +166,7 @@ void DoSerialise(SerialiserType &ser, RDMTL::VertexDescriptor &el)
 }
 
 template <typename SerialiserType>
-void DoSerialise(SerialiserType &ser, RDMTL::FunctionGroups &el)
+void DoSerialise(SerialiserType &ser, RDMTL::FunctionGroup &el)
 {
   SERIALISE_MEMBER(callsite);
   SERIALISE_MEMBER(functions);
@@ -229,6 +229,6 @@ INSTANTIATE_SERIALISE_TYPE(RDMTL::PipelineBufferDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexAttributeDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexBufferLayoutDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexDescriptor);
-INSTANTIATE_SERIALISE_TYPE(RDMTL::FunctionGroups);
+INSTANTIATE_SERIALISE_TYPE(RDMTL::FunctionGroup);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::LinkedFunctions);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPipelineDescriptor);

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -280,7 +280,7 @@ LinkedFunctions::LinkedFunctions(MTL::LinkedFunctions *objc)
       NS::Array *funcs = (NS::Array *)objcGroups->object(key);
       int countFuncs = funcs->count();
 
-      FunctionGroups &funcGroup = groups[i];
+      FunctionGroup &funcGroup = groups[i];
       funcGroup.callsite.assign(key->utf8String());
       funcGroup.functions.resize(countFuncs);
       for(int j = 0; j < countFuncs; ++j)
@@ -305,7 +305,7 @@ void LinkedFunctions::CopyTo(MTL::LinkedFunctions *objc)
       rdcarray<NS::String *> keys(countKeys);
       for(int i = 0; i < countKeys; ++i)
       {
-        FunctionGroups &funcGroup = groups[i];
+        FunctionGroup &funcGroup = groups[i];
         keys[i] = NS::String::string(funcGroup.callsite.data(), NS::UTF8StringEncoding);
         values[i] = CreateUnwrappedNSArray<MTL::Function *>(funcGroup.functions);
       }

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -108,21 +108,22 @@ struct TextureDescriptor
   TextureDescriptor() = default;
   TextureDescriptor(MTL::TextureDescriptor *objc);
   explicit operator MTL::TextureDescriptor *();
-  MTL::TextureType textureType;
-  MTL::PixelFormat pixelFormat;
-  NS::UInteger width;
-  NS::UInteger height;
-  NS::UInteger depth;
-  NS::UInteger mipmapLevelCount;
-  NS::UInteger sampleCount;
-  NS::UInteger arrayLength;
-  MTL::ResourceOptions resourceOptions;
-  MTL::CPUCacheMode cpuCacheMode;
-  MTL::StorageMode storageMode;
-  MTL::HazardTrackingMode hazardTrackingMode;
-  MTL::TextureUsage usage;
-  bool allowGPUOptimizedContents;
-  MTL::TextureSwizzleChannels swizzle;
+  MTL::TextureType textureType = MTL::TextureType2D;
+  MTL::PixelFormat pixelFormat = MTL::PixelFormatRGBA8Unorm;
+  NS::UInteger width = 1;
+  NS::UInteger height = 1;
+  NS::UInteger depth = 1;
+  NS::UInteger mipmapLevelCount = 1;
+  NS::UInteger sampleCount = 1;
+  NS::UInteger arrayLength = 1;
+  MTL::ResourceOptions resourceOptions = MTL::ResourceStorageModeManaged;
+  MTL::CPUCacheMode cpuCacheMode = MTL::CPUCacheModeDefaultCache;
+  MTL::StorageMode storageMode = MTL::StorageModeManaged;
+  MTL::HazardTrackingMode hazardTrackingMode = MTL::HazardTrackingModeDefault;
+  MTL::TextureUsage usage = MTL::TextureUsageShaderRead;
+  bool allowGPUOptimizedContents = true;
+  MTL::TextureSwizzleChannels swizzle = {MTL::TextureSwizzleRed, MTL::TextureSwizzleGreen,
+                                         MTL::TextureSwizzleBlue, MTL::TextureSwizzleAlpha};
 };
 
 // MTLRenderPipelineColorAttachmentDescriptor : based on the interface defined in
@@ -132,15 +133,15 @@ struct RenderPipelineColorAttachmentDescriptor
   RenderPipelineColorAttachmentDescriptor() = default;
   RenderPipelineColorAttachmentDescriptor(MTL::RenderPipelineColorAttachmentDescriptor *objc);
   void CopyTo(MTL::RenderPipelineColorAttachmentDescriptor *objc);
-  MTL::PixelFormat pixelFormat;
-  bool blendingEnabled;
-  MTL::BlendFactor sourceRGBBlendFactor;
-  MTL::BlendFactor destinationRGBBlendFactor;
-  MTL::BlendOperation rgbBlendOperation;
-  MTL::BlendFactor sourceAlphaBlendFactor;
-  MTL::BlendFactor destinationAlphaBlendFactor;
-  MTL::BlendOperation alphaBlendOperation;
-  MTL::ColorWriteMask writeMask;
+  MTL::PixelFormat pixelFormat = MTL::PixelFormatInvalid;
+  bool blendingEnabled = false;
+  MTL::BlendFactor sourceRGBBlendFactor = MTL::BlendFactorOne;
+  MTL::BlendFactor destinationRGBBlendFactor = MTL::BlendFactorZero;
+  MTL::BlendOperation rgbBlendOperation = MTL::BlendOperationAdd;
+  MTL::BlendFactor sourceAlphaBlendFactor = MTL::BlendFactorOne;
+  MTL::BlendFactor destinationAlphaBlendFactor = MTL::BlendFactorZero;
+  MTL::BlendOperation alphaBlendOperation = MTL::BlendOperationAdd;
+  MTL::ColorWriteMask writeMask = MTL::ColorWriteMaskAll;
 };
 
 // MTLPipelineBufferDescriptor : based on the interface defined in
@@ -150,7 +151,7 @@ struct PipelineBufferDescriptor
   PipelineBufferDescriptor() = default;
   PipelineBufferDescriptor(MTL::PipelineBufferDescriptor *objc);
   void CopyTo(MTL::PipelineBufferDescriptor *objc);
-  MTL::Mutability mutability;
+  MTL::Mutability mutability = MTL::MutabilityDefault;
 };
 
 // MTLVertexAttributeDescriptor : based on the interface defined in
@@ -160,9 +161,9 @@ struct VertexAttributeDescriptor
   VertexAttributeDescriptor() = default;
   VertexAttributeDescriptor(MTL::VertexAttributeDescriptor *objc);
   void CopyTo(MTL::VertexAttributeDescriptor *objc);
-  MTL::VertexFormat format;
-  NS::UInteger offset;
-  NS::UInteger bufferIndex;
+  MTL::VertexFormat format = MTL::VertexFormatInvalid;
+  NS::UInteger offset = 0;
+  NS::UInteger bufferIndex = 0;
 };
 
 // MTLVertexBufferLayoutDescriptor : based on the interface defined in
@@ -172,9 +173,9 @@ struct VertexBufferLayoutDescriptor
   VertexBufferLayoutDescriptor() = default;
   VertexBufferLayoutDescriptor(MTL::VertexBufferLayoutDescriptor *objc);
   void CopyTo(MTL::VertexBufferLayoutDescriptor *objc);
-  NS::UInteger stride;
-  MTL::VertexStepFunction stepFunction;
-  NS::UInteger stepRate;
+  NS::UInteger stride = 0;
+  MTL::VertexStepFunction stepFunction = MTL::VertexStepFunctionPerVertex;
+  NS::UInteger stepRate = 1;
 };
 
 // MTLVertexBufferLayoutDescriptor : based on the interface defined in
@@ -215,29 +216,31 @@ struct RenderPipelineDescriptor
   RenderPipelineDescriptor(MTL::RenderPipelineDescriptor *objc);
   explicit operator MTL::RenderPipelineDescriptor *();
   rdcstr label;
-  WrappedMTLFunction *vertexFunction;
-  WrappedMTLFunction *fragmentFunction;
+  WrappedMTLFunction *vertexFunction = NULL;
+  WrappedMTLFunction *fragmentFunction = NULL;
   VertexDescriptor vertexDescriptor;
-  NS::UInteger sampleCount;
-  NS::UInteger rasterSampleCount;
-  bool alphaToCoverageEnabled;
-  bool alphaToOneEnabled;
-  bool rasterizationEnabled;
-  NS::UInteger maxVertexAmplificationCount;
+  NS::UInteger sampleCount = 1;
+  NS::UInteger rasterSampleCount = 1;
+  bool alphaToCoverageEnabled = false;
+  bool alphaToOneEnabled = false;
+  bool rasterizationEnabled = true;
+  NS::UInteger maxVertexAmplificationCount = 1;
   rdcarray<RenderPipelineColorAttachmentDescriptor> colorAttachments;
-  MTL::PixelFormat depthAttachmentPixelFormat;
-  MTL::PixelFormat stencilAttachmentPixelFormat;
-  MTL::PrimitiveTopologyClass inputPrimitiveTopology;
-  MTL::TessellationPartitionMode tessellationPartitionMode;
-  NS::UInteger maxTessellationFactor;
-  bool tessellationFactorScaleEnabled;
-  MTL::TessellationFactorFormat tessellationFactorFormat;
-  MTL::TessellationControlPointIndexType tessellationControlPointIndexType;
-  MTL::TessellationFactorStepFunction tessellationFactorStepFunction;
-  MTL::Winding tessellationOutputWindingOrder;
+  MTL::PixelFormat depthAttachmentPixelFormat = MTL::PixelFormatInvalid;
+  MTL::PixelFormat stencilAttachmentPixelFormat = MTL::PixelFormatInvalid;
+  MTL::PrimitiveTopologyClass inputPrimitiveTopology = MTL::PrimitiveTopologyClassUnspecified;
+  MTL::TessellationPartitionMode tessellationPartitionMode = MTL::TessellationPartitionModePow2;
+  NS::UInteger maxTessellationFactor = 16;
+  bool tessellationFactorScaleEnabled = false;
+  MTL::TessellationFactorFormat tessellationFactorFormat = MTL::TessellationFactorFormatHalf;
+  MTL::TessellationControlPointIndexType tessellationControlPointIndexType =
+      MTL::TessellationControlPointIndexTypeNone;
+  MTL::TessellationFactorStepFunction tessellationFactorStepFunction =
+      MTL::TessellationFactorStepFunctionConstant;
+  MTL::Winding tessellationOutputWindingOrder = MTL::WindingClockwise;
   rdcarray<PipelineBufferDescriptor> vertexBuffers;
   rdcarray<PipelineBufferDescriptor> fragmentBuffers;
-  bool supportIndirectCommandBuffers;
+  bool supportIndirectCommandBuffers = false;
   // TODO: will MTL::BinaryArchive need to be a wrapped resource
   // rdcarray<MTL::BinaryArchive*> binaryArchives;
   // TODO: will MTL::DynamicLibrary need to be a wrapped resource
@@ -245,10 +248,10 @@ struct RenderPipelineDescriptor
   // rdcarray<MTL::DynamicLibrary*> fragmentPreloadedLibraries;
   LinkedFunctions vertexLinkedFunctions;
   LinkedFunctions fragmentLinkedFunctions;
-  bool supportAddingVertexBinaryFunctions;
-  bool supportAddingFragmentBinaryFunctions;
-  NS::UInteger maxVertexCallStackDepth;
-  NS::UInteger maxFragmentCallStackDepth;
+  bool supportAddingVertexBinaryFunctions = false;
+  bool supportAddingFragmentBinaryFunctions = false;
+  NS::UInteger maxVertexCallStackDepth = 1;
+  NS::UInteger maxFragmentCallStackDepth = 1;
 };
 
 }    // namespace RDMTL

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -189,7 +189,7 @@ struct VertexDescriptor
   rdcarray<VertexAttributeDescriptor> attributes;
 };
 
-struct FunctionGroups
+struct FunctionGroup
 {
   rdcstr callsite;
   rdcarray<WrappedMTLFunction *> functions;
@@ -204,7 +204,7 @@ struct LinkedFunctions
   void CopyTo(MTL::LinkedFunctions *objc);
   rdcarray<WrappedMTLFunction *> functions;
   rdcarray<WrappedMTLFunction *> binaryFunctions;
-  rdcarray<FunctionGroups> groups;
+  rdcarray<FunctionGroup> groups;
   rdcarray<WrappedMTLFunction *> privateFunctions;
 };
 
@@ -264,12 +264,21 @@ inline rdcliteral TypeName<NS::String *>()
 template <class SerialiserType>
 void DoSerialise(SerialiserType &ser, NS::String *&el);
 
-DECLARE_REFLECTION_STRUCT(RDMTL::TextureDescriptor);
-DECLARE_REFLECTION_STRUCT(RDMTL::RenderPipelineColorAttachmentDescriptor);
-DECLARE_REFLECTION_STRUCT(RDMTL::PipelineBufferDescriptor);
-DECLARE_REFLECTION_STRUCT(RDMTL::VertexAttributeDescriptor);
-DECLARE_REFLECTION_STRUCT(RDMTL::VertexBufferLayoutDescriptor);
-DECLARE_REFLECTION_STRUCT(RDMTL::VertexDescriptor);
-DECLARE_REFLECTION_STRUCT(RDMTL::FunctionGroups);
-DECLARE_REFLECTION_STRUCT(RDMTL::LinkedFunctions);
-DECLARE_REFLECTION_STRUCT(RDMTL::RenderPipelineDescriptor);
+#define RDMTL_DECLARE_REFLECTION_STRUCT(TYPE)    \
+  template <>                                    \
+  inline rdcliteral TypeName<RDMTL::TYPE>()      \
+  {                                              \
+    return STRING_LITERAL(STRINGIZE(MTL##TYPE)); \
+  }                                              \
+  template <class SerialiserType>                \
+  void DoSerialise(SerialiserType &ser, RDMTL::TYPE &el);
+
+RDMTL_DECLARE_REFLECTION_STRUCT(TextureDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(RenderPipelineColorAttachmentDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(PipelineBufferDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(VertexAttributeDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(VertexBufferLayoutDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(VertexDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(FunctionGroup);
+RDMTL_DECLARE_REFLECTION_STRUCT(LinkedFunctions);
+RDMTL_DECLARE_REFLECTION_STRUCT(RenderPipelineDescriptor);


### PR DESCRIPTION
## Description

- Fix infinite loop if an application calls `MTLCommandBuffer::enqueue`.
  - Searched the codebase (search pattern "[self ") for potential other cases like this and did not find any more occurrences.
- Changed the display name for the RDMTL serialization structs to be `MTL<TYPENAME>` instead of `RDMTL::<TYPENAME>`
- Initialize the member variables in the RDMTL serialization structs to match the default initialization of the MTL equivalent type.
  - The initialization change was verified by running code this like for each RDMTL type that can be constructed from an MTL type:
```
  {
    MTL::TextureDescriptor *objc = MTL::TextureDescriptor::alloc()->init();
    RDMTL::TextureDescriptor cpp(objc);
    RDMTL::TextureDescriptor cpp2;
    RDCASSERT(!memcmp(&cpp, &cpp2, sizeof(cpp)));
  }
```
- Minor tweak to some METAL helper macros to use consistent log channel and use ObjC runtime directly without relying on ObjC code.
- Change the `WrappedMTLDevice` APIs to `newTextureWithDescriptor` and `newRenderPipelineStateWithDescriptor` to use RDMTL descriptor types instead of the MTL descriptor types.
  - This means the wrapping and unwrapping of resources in the descriptor structs are all done by their helper/conversion APIs and do not require extra code when used ie. `WrappedMTLDevice`.
  - This makes the replay code easier to work with as now working with C++ structs instead of metal-cpp wrappers.
  - This brings consistency to the wrapped/unwrapped objects in the descriptor structs. The C++ structs always contain wrapped types and are strongly type whereas the ObjC structs could contain wrapped or unwrapped types depending on particular usage and rely on the correct casting of resource types.