### PR TITLE
Draft: Metal capture support for the presented MTLDrawable

### DIFF
--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -104,6 +104,7 @@ MTL::Drawable *hooked_CAMetalLayer_nextDrawable(id self, SEL _cmd)
   MTL::Device *mtlDevice = mtlLayer->device();
   RDCASSERT(object_getClass(mtlDevice) == objc_getClass("ObjCBridgeMTLDevice"));
   GetWrapped(mtlDevice)->RegisterMetalLayer(mtlLayer);
+  mtlLayer->setFramebufferOnly(false);
 
   RDCASSERTEQUAL(Threading::GetTLSValue(WrappedMTLDevice::g_nextDrawableTLSSlot), 0);
   Threading::SetTLSValue(WrappedMTLDevice::g_nextDrawableTLSSlot, (void *)(uintptr_t) true);

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -147,7 +147,7 @@ private:
 
   void CaptureClearSubmittedCmdBuffers();
   void CaptureCmdBufSubmit(MetalResourceRecord *record);
-  void EndCaptureFrame();
+  void EndCaptureFrame(ResourceId backbuffer);
 
   template <typename SerialiserType>
   bool Serialise_CaptureScope(SerialiserType &ser);
@@ -167,6 +167,7 @@ private:
   std::unordered_set<WrappedMTLTexture *> m_CapturePotentialBackBuffers;
   Threading::CriticalSection m_CaptureOutputLayersLock;
   std::unordered_set<CA::MetalLayer *> m_CaptureOutputLayers;
+  WrappedMTLTexture *m_CapturedBackbuffer = NULL;
 
   CaptureState m_State;
   bool m_AppControlledCapture = false;

--- a/renderdoc/driver/metal/metal_helpers_bridge.h
+++ b/renderdoc/driver/metal/metal_helpers_bridge.h
@@ -34,7 +34,6 @@ CA::MetalLayer *Get_Layer(MTL::Drawable *drawable);
 void CALayer_GetSize(void *layerHandle, int &width, int &height);
 void CAMetalLayer_Set_drawableSize(void *layerHandle, int w, int h);
 void CAMetalLayer_Set_device(void *layerHandle, MTL::Device *device);
-void CAMetalLayer_Set_framebufferOnly(void *layerHandle, bool enable);
 void CAMetalLayer_Set_pixelFormat(void *layerHandle, MTL::PixelFormat format);
 CA::MetalDrawable *CAMetalLayer_nextDrawable(void *layerHandle);
 };

--- a/renderdoc/driver/metal/metal_helpers_bridge.mm
+++ b/renderdoc/driver/metal/metal_helpers_bridge.mm
@@ -80,14 +80,6 @@ void ObjC::CAMetalLayer_Set_device(void *layerHandle, MTL::Device *device)
   metalLayer.device = id<MTLDevice>(device);
 }
 
-void ObjC::CAMetalLayer_Set_framebufferOnly(void *layerHandle, bool enable)
-{
-  CAMetalLayer *metalLayer = (CAMetalLayer *)layerHandle;
-  RDCASSERT([metalLayer isKindOfClass:[CAMetalLayer class]]);
-
-  metalLayer.framebufferOnly = enable ? YES : NO;
-}
-
 void ObjC::CAMetalLayer_Set_pixelFormat(void *layerHandle, MTL::PixelFormat format)
 {
   CAMetalLayer *metalLayer = (CAMetalLayer *)layerHandle;

--- a/renderdoc/driver/metal/official/metal-cpp.h
+++ b/renderdoc/driver/metal/official/metal-cpp.h
@@ -2900,7 +2900,7 @@ _NS_INLINE NS::View* NS::View::init( CGRect frame )
 
 _NS_INLINE void  NS::View::setWantsLayer( bool wantsLayer )
 {
-	Object::sendMessage< void >( this, _NS_PRIVATE_SEL( setWantsLayer_ ), wantsLayer ? YES : NO );
+	Object::sendMessage< void >( this, _NS_PRIVATE_SEL( setWantsLayer_ ), wantsLayer );
 }
 
 _NS_INLINE void  NS::View::setLayer( void* layer )
@@ -17804,6 +17804,8 @@ namespace Private
             "texture");
         _CA_PRIVATE_DEF_SEL(device,
             "device");
+        _CA_PRIVATE_DEF_SEL(setFramebufferOnly_,
+            "setFramebufferOnly:");
 
     } // Class
 } // Private
@@ -17853,6 +17855,7 @@ namespace CA
     public:
       static MetalLayer*    layer();
       MTL::Device*          device() const;
+      void                  setFramebufferOnly(bool enabled);
   };
 }
 
@@ -17863,5 +17866,10 @@ _NS_INLINE CA::MetalLayer* CA::MetalLayer::layer()
 
 _CA_INLINE MTL::Device* CA::MetalLayer::device() const
 {
-    return Object::sendMessage<MTL::Device*>(this, _CA_PRIVATE_SEL(device));
+    return Object::sendMessage< MTL::Device* >(this, _CA_PRIVATE_SEL( device ));
+}
+
+_CA_INLINE void CA::MetalLayer::setFramebufferOnly(bool framebufferOnly)
+{
+    Object::sendMessage< void >( this, _CA_PRIVATE_SEL( setFramebufferOnly_ ), framebufferOnly );
 }


### PR DESCRIPTION
## Description

* Generate the capture thumbnail image from the presented `MTLTexture`
* Serialize the capture `PresentedImage` ID in the `CaptureEnd` chunk.

Added `CA::MetalLayer::setFramebufferOnly` to metal-cpp and deleted helper `ObjC::CAMetalLayer_Set_framebufferOnly`