### PR TITLE
Fix failing BufferFormat unit tests on Linux, Mac, and Windows

### DIFF
--- a/qrenderdoc/Code/BufferFormatter.cpp
+++ b/qrenderdoc/Code/BufferFormatter.cpp
@@ -5781,7 +5781,7 @@ enum e : foo {
 
 e data;
 )",
-           1, "unsigned integer"},
+           1, "integer type"},
           {R"(
 enum e : uint {
   val = blah,

--- a/qrenderdoc/Code/qrenderdoc.cpp
+++ b/qrenderdoc/Code/qrenderdoc.cpp
@@ -258,7 +258,6 @@ int main(int argc, char *argv[])
       else
       {
         logstream << "Python bindings are consistent.\n";
-        ret = 0;
       }
     }
 


### PR DESCRIPTION
## Description

Do not clear catch failure return state.

Previously the python binding consistency tests were resetting the return status to 0 if the python tests pass even if the catch unit tests had failed.

This was masking this failing unit test on Mac, Linux, and Windows.
```
-------------------------------------------------------------------------------
Buffer format parsing
  errors
-------------------------------------------------------------------------------
../../qrenderdoc/Code/BufferFormatter.cpp:5353
...............................................................................
../../qrenderdoc/Code/BufferFormatter.cpp:5859: FAILED:
  CHECK( parsed.errors[err.line].contains(err.error, Qt::CaseInsensitive) )
with expansion:
  false
```

Looks like this commit 9bde5324b6ac89d473e04269c98b521d9f48ca7d changed the reported error message from
`Invalid enum base type '%1', must be an unsigned integer type.`
to
`Invalid enum base type '%1', must be an integer type.`

and the test was expecting the error message to contain `unsigned integer`

Changed the expected error message to contain `integer type` to make the test pass.

[Link](https://github.com/Zorro666/renderdoc/actions/runs/2561734321) showing the test failing before the code fix for the test 