### PR TITLE
WIP: Pre-requisites to support basic Metal capture 

### DIFF
--- a/renderdoc/driver/metal/metal_command_buffer.cpp
+++ b/renderdoc/driver/metal/metal_command_buffer.cpp
@@ -25,6 +25,7 @@
 #include "metal_command_buffer.h"
 #include "metal_blit_command_encoder.h"
 #include "metal_device.h"
+#include "metal_helpers_bridge.h"
 #include "metal_render_command_encoder.h"
 #include "metal_resources.h"
 #include "metal_texture.h"
@@ -163,6 +164,9 @@ bool WrappedMTLCommandBuffer::Serialise_presentDrawable(SerialiserType &ser, MTL
 
 void WrappedMTLCommandBuffer::presentDrawable(MTL::Drawable *drawable)
 {
+  // To avoid metal assert about accessing drawable texture after calling present
+  MTL::Texture *mtlBackBuffer = ObjC::Get_Texture(drawable);
+
   SERIALISE_TIME_CALL(Unwrap(this)->presentDrawable(drawable));
   if(IsCaptureMode(m_State))
   {
@@ -173,10 +177,11 @@ void WrappedMTLCommandBuffer::presentDrawable(MTL::Drawable *drawable)
       Serialise_presentDrawable(ser, drawable);
       chunk = scope.Get();
     }
-    MetalResourceRecord *record = GetRecord(this);
-    record->AddChunk(chunk);
-    record->cmdInfo->present = true;
-    record->cmdInfo->drawable = drawable;
+    MetalResourceRecord *bufferRecord = GetRecord(this);
+    bufferRecord->AddChunk(chunk);
+    bufferRecord->cmdInfo->flags |= MetalCmdBuffer_Present;
+    bufferRecord->cmdInfo->outputLayer = ObjC::Get_Layer(drawable);
+    bufferRecord->cmdInfo->backBuffer = GetWrapped(mtlBackBuffer);
   }
   else
   {

--- a/renderdoc/driver/metal/metal_command_buffer.cpp
+++ b/renderdoc/driver/metal/metal_command_buffer.cpp
@@ -229,6 +229,80 @@ void WrappedMTLCommandBuffer::commit()
   }
 }
 
+template <typename SerialiserType>
+bool WrappedMTLCommandBuffer::Serialise_enqueue(SerialiserType &ser)
+{
+  SERIALISE_ELEMENT_LOCAL(CommandBuffer, this);
+
+  SERIALISE_CHECK_READ_ERRORS();
+
+  // TODO: implement RD MTL replay
+  if(IsReplayingAndReading())
+  {
+  }
+  return true;
+}
+
+void WrappedMTLCommandBuffer::enqueue()
+{
+  SERIALISE_TIME_CALL(Unwrap(this)->enqueue());
+  if(IsCaptureMode(m_State))
+  {
+    Chunk *chunk = NULL;
+    {
+      CACHE_THREAD_SERIALISER();
+      SCOPED_SERIALISE_CHUNK(MetalChunk::MTLCommandBuffer_enqueue);
+      Serialise_enqueue(ser);
+      chunk = scope.Get();
+    }
+    MetalResourceRecord *bufferRecord = GetRecord(this);
+    bufferRecord->AddChunk(chunk);
+  }
+  else
+  {
+    // TODO: implement RD MTL replay
+  }
+}
+
+template <typename SerialiserType>
+bool WrappedMTLCommandBuffer::Serialise_waitUntilCompleted(SerialiserType &ser)
+{
+  SERIALISE_ELEMENT_LOCAL(CommandBuffer, this);
+
+  SERIALISE_CHECK_READ_ERRORS();
+
+  // TODO: implement RD MTL replay
+  if(IsReplayingAndReading())
+  {
+  }
+  return true;
+}
+
+void WrappedMTLCommandBuffer::waitUntilCompleted()
+{
+  SERIALISE_TIME_CALL(Unwrap(this)->waitUntilCompleted());
+  if(IsCaptureMode(m_State))
+  {
+    bool capframe = IsActiveCapturing(m_State);
+    if(capframe)
+    {
+      Chunk *chunk = NULL;
+      {
+        CACHE_THREAD_SERIALISER();
+        SCOPED_SERIALISE_CHUNK(MetalChunk::MTLCommandBuffer_waitUntilCompleted);
+        Serialise_waitUntilCompleted(ser);
+        chunk = scope.Get();
+      }
+      MetalResourceRecord *bufferRecord = GetRecord(this);
+      bufferRecord->AddChunk(chunk);
+    }
+  }
+  else
+  {
+    // TODO: implement RD MTL replay
+  }
+}
+
 INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLCommandBuffer,
                                             WrappedMTLBlitCommandEncoder *encoder,
                                             blitCommandEncoder);
@@ -239,3 +313,5 @@ INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLCommandBuffer,
 INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLCommandBuffer, void, presentDrawable,
                                 MTL::Drawable *drawable);
 INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLCommandBuffer, void, commit);
+INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLCommandBuffer, void, enqueue);
+INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLCommandBuffer, void, waitUntilCompleted);

--- a/renderdoc/driver/metal/metal_command_buffer.h
+++ b/renderdoc/driver/metal/metal_command_buffer.h
@@ -36,7 +36,7 @@ public:
                           WrappedMTLDevice *wrappedMTLDevice);
 
   void SetCommandQueue(WrappedMTLCommandQueue *commandQueue) { m_CommandQueue = commandQueue; }
-  MTL::CommandQueue *GetCommandQueue() { return (MTL::CommandQueue *)m_CommandQueue; }
+  WrappedMTLCommandQueue *GetCommandQueue() { return m_CommandQueue; }
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLBlitCommandEncoder *, blitCommandEncoder);
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLRenderCommandEncoder *,
                                           renderCommandEncoderWithDescriptor,

--- a/renderdoc/driver/metal/metal_command_buffer.h
+++ b/renderdoc/driver/metal/metal_command_buffer.h
@@ -43,6 +43,8 @@ public:
                                           RDMTL::RenderPassDescriptor &descriptor);
   DECLARE_FUNCTION_SERIALISED(void, presentDrawable, MTL::Drawable *drawable);
   DECLARE_FUNCTION_SERIALISED(void, commit);
+  DECLARE_FUNCTION_SERIALISED(void, enqueue);
+  DECLARE_FUNCTION_SERIALISED(void, waitUntilCompleted);
 
   enum
   {

--- a/renderdoc/driver/metal/metal_command_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_command_buffer_bridge.mm
@@ -122,8 +122,7 @@
 
 - (void)enqueue
 {
-  METAL_NOT_HOOKED();
-  [self.real enqueue];
+  GetWrapped(self)->enqueue();
 }
 
 - (void)commit
@@ -170,8 +169,7 @@
 
 - (void)waitUntilCompleted
 {
-  METAL_NOT_HOOKED();
-  return [self.real waitUntilCompleted];
+  GetWrapped(self)->waitUntilCompleted();
 }
 
 - (MTLCommandBufferStatus)status

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -124,6 +124,14 @@ inline MTL::Resource *Unwrap(WrappedMTLResource *obj)
   return Unwrap<MTL::Resource *>((WrappedMTLObject *)obj);
 }
 
+enum MetalCmdBufferStatus
+{
+  MetalCmdBuffer_Enqueued = 1 << 0,
+  MetalCmdBuffer_Committed = 1 << 1,
+  MetalCmdBuffer_Submitted = 1 << 2,
+  MetalCmdBuffer_Present = 1 << 3,
+};
+
 struct MetalCmdBufferRecordingInfo
 {
   MetalCmdBufferRecordingInfo(WrappedMTLCommandQueue *parentQueue)

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -134,10 +134,7 @@ enum MetalCmdBufferStatus
 
 struct MetalCmdBufferRecordingInfo
 {
-  MetalCmdBufferRecordingInfo(WrappedMTLCommandQueue *parentQueue)
-      : queue(parentQueue), present(false), drawable(NULL)
-  {
-  }
+  MetalCmdBufferRecordingInfo(WrappedMTLCommandQueue *parentQueue) : queue(parentQueue) {}
   MetalCmdBufferRecordingInfo() = delete;
   MetalCmdBufferRecordingInfo(const MetalCmdBufferRecordingInfo &) = delete;
   MetalCmdBufferRecordingInfo(MetalCmdBufferRecordingInfo &&) = delete;
@@ -145,10 +142,11 @@ struct MetalCmdBufferRecordingInfo
   ~MetalCmdBufferRecordingInfo() {}
   WrappedMTLCommandQueue *queue;
 
-  // The drawable that present was called on
-  MTL::Drawable *drawable;
-  // AdvanceFrame/Present should be called after this buffer is committed.
-  bool present;
+  // The MetalLayer to present
+  CA::MetalLayer *outputLayer = NULL;
+  // The texture to present
+  WrappedMTLTexture *backBuffer = NULL;
+  uint32_t flags = 0;
 };
 
 struct MetalResourceRecord : public ResourceRecord

--- a/renderdoc/driver/metal/metal_stringise.cpp
+++ b/renderdoc/driver/metal/metal_stringise.cpp
@@ -1145,3 +1145,16 @@ rdcstr DoStringise(const MetalResourceType &el)
   }
   END_ENUM_STRINGISE();
 }
+
+template <>
+rdcstr DoStringise(const MetalCmdBufferStatus &el)
+{
+  BEGIN_BITFIELD_STRINGISE(MetalCmdBufferStatus)
+  {
+    STRINGISE_BITFIELD_BIT(MetalCmdBuffer_Enqueued);
+    STRINGISE_BITFIELD_BIT(MetalCmdBuffer_Committed);
+    STRINGISE_BITFIELD_BIT(MetalCmdBuffer_Submitted);
+    STRINGISE_BITFIELD_BIT(MetalCmdBuffer_Present);
+  }
+  END_BITFIELD_STRINGISE()
+}


### PR DESCRIPTION
## Description

Hooking and capture serialization for `MTLCommandBuffer` APIs `enqueue` and `waitUntilCompleted` (required to capture test programs with `enqueue` support). These chunks are added to the command buffer record in order that the chunks are only included in the capture when the command buffer is included. The replay support for these APIs treats them at the global scope and not replayed within the command buffer. The `enqueue` chunk might not be required or used by replay in the future (currently it is used to verify the order of command buffer reply matches what is expected).

Updated the `MetalCmdBufferRecordingInfo` struct to store the `CA::MetalLayer` & `WrappedMTLTexture` from the `MTL::Drawable` instead of the `MTL::Drawable`. This avoids validation asserts about accessing the texture of an `MTL::Drawable` after calling `MTLCommandBuffer::presentDrawable`. 

Changed member data `bool present` to `uint32_t flags` to be able to efficiently store more than one flag. Added `MetalCmdBufferStatus` enum to store different status flags.

Changed the return of `WrappedMTLCommandBuffer::GetCommandQueueReturn` to be a `WrappedMTLCommandQueue *` instead of `MTL::CommandQueue *`. It makes sense and is more natural to return the `m_CommandQueue` without casting it. The previous API usage was for the Objective C bridge layer which worked with `MTL::CommandQueue *. This is not required now the Objective C and C++ wrapping/unwrapping has been simplified.

This PR represents the final Objective C change in the current Metal development branch 🥳 
