### PR TITLE
Add support for Wrapped Metal resource deallocation

### DIFF
--- a/renderdoc/driver/metal/metal_blit_command_encoder_bridge.mm
+++ b/renderdoc/driver/metal/metal_blit_command_encoder_bridge.mm
@@ -40,7 +40,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_buffer_bridge.mm
@@ -40,7 +40,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_command_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_command_buffer_bridge.mm
@@ -40,7 +40,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_command_queue_bridge.mm
+++ b/renderdoc/driver/metal/metal_command_queue_bridge.mm
@@ -40,7 +40,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -37,6 +37,15 @@ WrappedMTLDevice::WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId)
 {
   AllocateObjCBridge(this);
   m_Device = this;
+
+  if(RenderDoc::Inst().IsReplayApp())
+  {
+  }
+  else
+  {
+    m_State = CaptureState::BackgroundCapturing;
+  }
+
   threadSerialiserTLSSlot = Threading::AllocateTLSSlot();
 
   m_ResourceManager = new MetalResourceManager(m_State, this);

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -43,7 +43,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_function_bridge.mm
+++ b/renderdoc/driver/metal/metal_function_bridge.mm
@@ -40,7 +40,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_library_bridge.mm
+++ b/renderdoc/driver/metal/metal_library_bridge.mm
@@ -40,7 +40,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_manager.h
+++ b/renderdoc/driver/metal/metal_manager.h
@@ -117,6 +117,22 @@ public:
     return id;
   }
 
+  template <typename wrappedtype>
+  void ReleaseWrappedResource(wrappedtype *wrapped)
+  {
+    ResourceId id = GetResID(wrapped);
+
+    // TODO: implement RD MTL replay
+
+    ResourceManager::ReleaseCurrentResource(id);
+    MetalResourceRecord *record = GetRecord(wrapped);
+    if(record)
+    {
+      record->Delete(this);
+    }
+    delete wrapped;
+  }
+
   using ResourceManager::AddResourceRecord;
 
   template <typename wrappedtype>

--- a/renderdoc/driver/metal/metal_render_command_encoder_bridge.mm
+++ b/renderdoc/driver/metal/metal_render_command_encoder_bridge.mm
@@ -40,7 +40,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_render_pipeline_state_bridge.mm
+++ b/renderdoc/driver/metal/metal_render_pipeline_state_bridge.mm
@@ -40,7 +40,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_resources.cpp
+++ b/renderdoc/driver/metal/metal_resources.cpp
@@ -47,11 +47,6 @@ ResourceId GetResID(WrappedMTLObject *obj)
 METALCPP_WRAPPED_PROTOCOLS(IMPLEMENT_WRAPPED_TYPE_HELPERS)
 #undef IMPLEMENT_WRAPPED_TYPE_HELPERS
 
-void WrappedMTLObject::Dealloc()
-{
-  // TODO: call the wrapped object destructor
-}
-
 MetalResourceManager *WrappedMTLObject::GetResourceManager()
 {
   return m_Device->GetResourceManager();

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -64,8 +64,6 @@ struct WrappedMTLObject
   }
   ~WrappedMTLObject() = default;
 
-  void Dealloc();
-
   MTL::Device *GetDevice() { return (MTL::Device *)m_Device; }
   MetalResourceManager *GetResourceManager();
 

--- a/renderdoc/driver/metal/metal_texture_bridge.mm
+++ b/renderdoc/driver/metal/metal_texture_bridge.mm
@@ -40,7 +40,7 @@
 #pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
 - (void)dealloc
 {
-  GetWrapped(self)->Dealloc();
+  DeallocateObjCBridge(GetWrapped(self));
 }
 #pragma clang diagnostic pop
 

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -65,6 +65,11 @@ RDCCOMPILE_ASSERT(sizeof(NS::UInteger) == sizeof(std::uintptr_t),
       ((MTL::CPPTYPE *)objc)->release();                                                          \
     }                                                                                             \
   }                                                                                               \
+  void DeallocateObjCBridge(WrappedMTL##CPPTYPE *wrappedCPP)                                      \
+  {                                                                                               \
+    wrappedCPP->m_ObjcBridge = NULL;                                                              \
+    wrappedCPP->m_Real = NULL;                                                                    \
+    wrappedCPP->GetResourceManager()->ReleaseWrappedResource(wrappedCPP);                         \
   }
 
 METALCPP_WRAPPED_PROTOCOLS(DEFINE_OBJC_HELPERS)

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -73,7 +73,8 @@ DECLARE_WRAPPED_TYPE_SERIALISE(Resource)
   {                                                             \
     return (WrappedMTL##CPPTYPE *)cppType;                      \
   }                                                             \
-  extern void AllocateObjCBridge(WrappedMTL##CPPTYPE *wrapped);
+  extern void AllocateObjCBridge(WrappedMTL##CPPTYPE *wrapped); \
+  extern void DeallocateObjCBridge(WrappedMTL##CPPTYPE *wrapped);
 
 METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)
 #undef DECLARE_OBJC_HELPERS


### PR DESCRIPTION
## Description

Added `DeallocateObjCBridge(WrappedMTL<type> *)` to replace `WrappedMTLObject::Dealloc()` (the implementation was a TODO).
`DeallocateObjCBridge` calls `MetalResourceManager::ReleaseWrappedResource()`.

Used `objc_constructInstance` in `AllocateObjCBridge` to fix a bug where the reference count of the ObjC bridge class was not guaranteed to be initialized on construction. 

Deleted `WrappedMTLObject::Dealloc()`
