### PR TITLE
Extend enum text serialisation

### DIFF
--- a/renderdoc/serialise/codecs/xml_codec.cpp
+++ b/renderdoc/serialise/codecs/xml_codec.cpp
@@ -201,7 +201,7 @@ static void Obj2XML(pugi::xml_node &parent, SDObject &child)
 
   if(child.type.basetype == SDBasic::UnsignedInteger ||
      child.type.basetype == SDBasic::SignedInteger || child.type.basetype == SDBasic::Float ||
-     child.type.basetype == SDBasic::Resource)
+     child.type.basetype == SDBasic::Resource || child.type.basetype == SDBasic::Enum)
   {
     obj.append_attribute("width") = child.type.byteSize;
   }
@@ -490,10 +490,11 @@ static SDObject *XML2Obj(pugi::xml_node &obj)
     }
   }
 
-  if(ret->type.basetype == SDBasic::UnsignedInteger || ret->type.basetype == SDBasic::SignedInteger ||
-     ret->type.basetype == SDBasic::Float || ret->type.basetype == SDBasic::Resource)
+  if(ret->type.basetype == SDBasic::UnsignedInteger ||
+     ret->type.basetype == SDBasic::SignedInteger || ret->type.basetype == SDBasic::Float ||
+     ret->type.basetype == SDBasic::Resource || ret->type.basetype == SDBasic::Enum)
   {
-    ret->type.byteSize = obj.attribute("width").as_uint();
+    ret->type.byteSize = obj.attribute("width").as_uint(4);
   }
 
   if(obj.attribute("hidden"))

--- a/renderdoc/serialise/serialiser.cpp
+++ b/renderdoc/serialise/serialiser.cpp
@@ -813,15 +813,10 @@ void DoSerialise(SerialiserType &ser, SDObject *el)
       }
       break;
     }
-    case SDBasic::Enum:
-    {
-      uint32_t e = (uint32_t)el->data.basic.u;
-      ser.Serialise(""_lit, e);
-      break;
-    }
     case SDBasic::Boolean: ser.Serialise(""_lit, el->data.basic.b); break;
     case SDBasic::Character: ser.Serialise(""_lit, el->data.basic.c); break;
     case SDBasic::Resource: ser.Serialise(""_lit, el->data.basic.id); break;
+    case SDBasic::Enum:
     case SDBasic::UnsignedInteger:
       if(el->type.byteSize == 1)
       {


### PR DESCRIPTION
## Description

Extend the structured serialisation and the XML to/from `SDObject` serialisation to support enums which are not 4-byte's in size.

Before this change enums were assumed to be 4-bytes in size which led to incorrect serialisation from `RDC` to XML to `RDC` on chunks which contained non 4-byte enums.

Extended an existing StructuredFile serialisation test to include basic support for 1/2/8 byte enums (the test already covers 4 byte enums).

Added new `SDObject` -> `XML` -> `SDObject` round trip tests directly to xml_codecs.cpp to verify the XML serialisation changes.