### PR TITLE
Metal: Compile time support for MacOS SDK 13.1

### DIFF
--- a/renderdoc/driver/metal/metal_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_buffer_bridge.mm
@@ -63,7 +63,7 @@
 }
 
 // MTLResource : based on the protocol defined in
-// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLResource.h
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLResource.h
 
 - (nullable NSString *)label
 {
@@ -184,6 +184,11 @@
 {
   METAL_NOT_HOOKED();
   return [self.real newRemoteBufferViewForDevice:device];
+}
+
+- (uint64_t)gpuAddress API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  return self.real.gpuAddress;
 }
 
 @end

--- a/renderdoc/driver/metal/metal_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_buffer_bridge.mm
@@ -186,9 +186,11 @@
   return [self.real newRemoteBufferViewForDevice:device];
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (uint64_t)gpuAddress API_AVAILABLE(macos(13.0), ios(16.0))
 {
   return self.real.gpuAddress;
 }
+#endif
 
 @end

--- a/renderdoc/driver/metal/metal_command_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_command_buffer_bridge.mm
@@ -63,7 +63,7 @@
 }
 
 // MTLCommandBuffer : based on the protocol defined in
-// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLCommandBuffer.h
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLCommandBuffer.h
 
 - (id<MTLDevice>)device
 {
@@ -263,6 +263,13 @@
 {
   METAL_NOT_HOOKED();
   return [self.real accelerationStructureCommandEncoder];
+}
+
+- (id<MTLAccelerationStructureCommandEncoder>)accelerationStructureCommandEncoderWithDescriptor:
+    (MTLAccelerationStructurePassDescriptor *)descriptor API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real accelerationStructureCommandEncoderWithDescriptor:descriptor];
 }
 
 - (void)pushDebugGroup:(NSString *)string API_AVAILABLE(macos(10.13), ios(11.0))

--- a/renderdoc/driver/metal/metal_command_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_command_buffer_bridge.mm
@@ -265,12 +265,14 @@
   return [self.real accelerationStructureCommandEncoder];
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (id<MTLAccelerationStructureCommandEncoder>)accelerationStructureCommandEncoderWithDescriptor:
     (MTLAccelerationStructurePassDescriptor *)descriptor API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real accelerationStructureCommandEncoderWithDescriptor:descriptor];
 }
+#endif
 
 - (void)pushDebugGroup:(NSString *)string API_AVAILABLE(macos(10.13), ios(11.0))
 {

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -526,6 +526,7 @@ newRenderPipelineStateWithTileDescriptor:(MTLTileRenderPipelineDescriptor *)desc
                                            completionHandler:completionHandler];
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (nullable id<MTLRenderPipelineState>)
 newRenderPipelineStateWithMeshDescriptor:(MTLMeshRenderPipelineDescriptor *)descriptor
                                  options:(MTLPipelineOption)options
@@ -539,7 +540,9 @@ newRenderPipelineStateWithMeshDescriptor:(MTLMeshRenderPipelineDescriptor *)desc
                                                   reflection:reflection
                                                        error:error];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)newRenderPipelineStateWithMeshDescriptor:(MTLMeshRenderPipelineDescriptor *)descriptor
                                          options:(MTLPipelineOption)options
                                completionHandler:
@@ -551,6 +554,7 @@ newRenderPipelineStateWithMeshDescriptor:(MTLMeshRenderPipelineDescriptor *)desc
                                                      options:options
                                            completionHandler:completionHandler];
 }
+#endif
 
 - (NSUInteger)maxThreadgroupMemoryLength API_AVAILABLE(macos(10.13), ios(11.0))
 {
@@ -641,6 +645,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   return self.real.peerCount;
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (nullable id<MTLIOFileHandle>)newIOHandleWithURL:(NSURL *)url
                                              error:(NSError **)error
     API_AVAILABLE(macos(13.0), ios(16.0))
@@ -648,7 +653,9 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   METAL_NOT_HOOKED();
   return [self.real newIOHandleWithURL:url error:error];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (nullable id<MTLIOCommandQueue>)newIOCommandQueueWithDescriptor:(MTLIOCommandQueueDescriptor *)descriptor
                                                             error:(NSError **)error
     API_AVAILABLE(macos(13.0), ios(16.0))
@@ -656,7 +663,9 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   METAL_NOT_HOOKED();
   return [self.real newIOCommandQueueWithDescriptor:descriptor error:error];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (nullable id<MTLIOFileHandle>)newIOHandleWithURL:(NSURL *)url
                                  compressionMethod:(MTLIOCompressionMethod)compressionMethod
                                              error:(NSError **)error
@@ -665,6 +674,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   METAL_NOT_HOOKED();
   return [self.real newIOHandleWithURL:url compressionMethod:compressionMethod error:error];
 }
+#endif
 
 - (MTLSize)sparseTileSizeWithTextureType:(MTLTextureType)textureType
                              pixelFormat:(MTLPixelFormat)pixelFormat
@@ -710,13 +720,16 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                                   numRegions:numRegions];
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (NSUInteger)sparseTileSizeInBytesForSparsePageSize:(MTLSparsePageSize)sparsePageSize
     API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real sparseTileSizeInBytesForSparsePageSize:sparsePageSize];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (MTLSize)sparseTileSizeWithTextureType:(MTLTextureType)textureType
                              pixelFormat:(MTLPixelFormat)pixelFormat
                              sampleCount:(NSUInteger)sampleCount
@@ -729,6 +742,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                                       sampleCount:sampleCount
                                    sparsePageSize:sparsePageSize];
 }
+#endif
 
 - (NSUInteger)maxBufferLength API_AVAILABLE(macos(10.14), ios(12.0))
 {
@@ -756,12 +770,14 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   return [self.real sampleTimestamps:cpuTimestamp gpuTimestamp:gpuTimestamp];
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (id<MTLArgumentEncoder>)newArgumentEncoderWithBufferBinding:(id<MTLBufferBinding>)bufferBinding
     API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real newArgumentEncoderWithBufferBinding:bufferBinding];
 }
+#endif
 
 - (BOOL)supportsCounterSampling:(MTLCounterSamplingPoint)samplingPoint
     API_AVAILABLE(macos(11.0), ios(14.0))
@@ -835,19 +851,23 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   return [self.real newAccelerationStructureWithDescriptor:descriptor];
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (MTLSizeAndAlign)heapAccelerationStructureSizeAndAlignWithSize:(NSUInteger)size
     API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real heapAccelerationStructureSizeAndAlignWithSize:size];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (MTLSizeAndAlign)heapAccelerationStructureSizeAndAlignWithDescriptor:
     (MTLAccelerationStructureDescriptor *)descriptor API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real heapAccelerationStructureSizeAndAlignWithDescriptor:descriptor];
 }
+#endif
 
 - (BOOL)supportsFunctionPointers API_AVAILABLE(macos(11.0), ios(14.0))
 {

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -66,7 +66,7 @@
 }
 
 // MTLDevice : based on the protocol defined in
-// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLDevice.h
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLDevice.h
 
 - (NSString *)name
 {
@@ -160,11 +160,7 @@
   return GetWrapped(self)->supportsQueryTextureLOD();
 }
 
-- (BOOL)supportsBCTextureCompression API_AVAILABLE(macos(11.0))
-// It is available for ios in SDK 11.1 and it is marked as unavailable in SDK 12
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
-    API_UNAVAILABLE(ios)
-#endif    // #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
+- (BOOL)supportsBCTextureCompression API_AVAILABLE(macos(11.0))API_UNAVAILABLE(ios)
 {
   return GetWrapped(self)->supportsBCTextureCompression();
 }
@@ -173,12 +169,15 @@
 {
   return GetWrapped(self)->supportsPullModelInterpolation();
 }
-- (BOOL)areBarycentricCoordsSupported API_AVAILABLE(macos(10.15))API_UNAVAILABLE(ios)
+
+- (BOOL)areBarycentricCoordsSupported
+    API_DEPRECATED_WITH_REPLACEMENT("supportsShaderBarycentricCoordinates", macos(10.15, 13.0),
+                                    ios(14.0, 16.0))API_UNAVAILABLE(tvos)
 {
   return GetWrapped(self)->areBarycentricCoordsSupported();
 }
 
-- (BOOL)supportsShaderBarycentricCoordinates API_AVAILABLE(macos(10.15))API_UNAVAILABLE(ios)
+- (BOOL)supportsShaderBarycentricCoordinates API_AVAILABLE(macos(10.15), ios(14.0))
 {
   return GetWrapped(self)->supportsShaderBarycentricCoordinates();
 }
@@ -304,6 +303,7 @@
 
 - (nullable id<MTLLibrary>)newLibraryWithFile:(NSString *)filepath
                                         error:(__autoreleasing NSError **)error
+    API_DEPRECATED("Use -newLibraryWithURL:error: instead", macos(10.11, 13.0), ios(8.0, 16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real newLibraryWithFile:filepath error:error];
@@ -341,7 +341,6 @@
       [self.real newLibraryWithSource:source options:options completionHandler:completionHandler];
 }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (nullable id<MTLLibrary>)newLibraryWithStitchedDescriptor:(MTLStitchedLibraryDescriptor *)descriptor
                                                       error:(__autoreleasing NSError **)error
     API_AVAILABLE(macos(12.0), ios(15.0))
@@ -349,9 +348,7 @@
   METAL_NOT_HOOKED();
   return [self.real newLibraryWithStitchedDescriptor:descriptor error:error];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)newLibraryWithStitchedDescriptor:(MTLStitchedLibraryDescriptor *)descriptor
                        completionHandler:(MTLNewLibraryCompletionHandler)completionHandler
     API_AVAILABLE(macos(12.0), ios(15.0))
@@ -359,7 +356,6 @@
   METAL_NOT_HOOKED();
   [self.real newLibraryWithStitchedDescriptor:descriptor completionHandler:completionHandler];
 }
-#endif
 
 - (nullable id<MTLRenderPipelineState>)
 newRenderPipelineStateWithDescriptor:(MTLRenderPipelineDescriptor *)descriptor
@@ -475,6 +471,7 @@ newComputePipelineStateWithDescriptor:(MTLComputePipelineDescriptor *)descriptor
 }
 
 - (BOOL)supportsFeatureSet:(MTLFeatureSet)featureSet
+    API_DEPRECATED("Use supportsFamily instead", macos(10.11, 13.0), ios(8.0, 16.0), tvos(9.0, 16.0))
 {
   return GetWrapped(self)->supportsFeatureSet((MTL::FeatureSet)featureSet);
 }
@@ -525,6 +522,32 @@ newRenderPipelineStateWithTileDescriptor:(MTLTileRenderPipelineDescriptor *)desc
 {
   METAL_NOT_HOOKED();
   return [self.real newRenderPipelineStateWithTileDescriptor:descriptor
+                                                     options:options
+                                           completionHandler:completionHandler];
+}
+
+- (nullable id<MTLRenderPipelineState>)
+newRenderPipelineStateWithMeshDescriptor:(MTLMeshRenderPipelineDescriptor *)descriptor
+                                 options:(MTLPipelineOption)options
+                              reflection:(MTLAutoreleasedRenderPipelineReflection *__nullable)reflection
+                                   error:(__autoreleasing NSError **)error
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newRenderPipelineStateWithMeshDescriptor:descriptor
+                                                     options:options
+                                                  reflection:reflection
+                                                       error:error];
+}
+
+- (void)newRenderPipelineStateWithMeshDescriptor:(MTLMeshRenderPipelineDescriptor *)descriptor
+                                         options:(MTLPipelineOption)options
+                               completionHandler:
+                                   (MTLNewRenderPipelineStateWithReflectionCompletionHandler)
+                                       completionHandler API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newRenderPipelineStateWithMeshDescriptor:descriptor
                                                      options:options
                                            completionHandler:completionHandler];
 }
@@ -618,6 +641,31 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   return self.real.peerCount;
 }
 
+- (nullable id<MTLIOFileHandle>)newIOHandleWithURL:(NSURL *)url
+                                             error:(NSError **)error
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newIOHandleWithURL:url error:error];
+}
+
+- (nullable id<MTLIOCommandQueue>)newIOCommandQueueWithDescriptor:(MTLIOCommandQueueDescriptor *)descriptor
+                                                            error:(NSError **)error
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newIOCommandQueueWithDescriptor:descriptor error:error];
+}
+
+- (nullable id<MTLIOFileHandle>)newIOHandleWithURL:(NSURL *)url
+                                 compressionMethod:(MTLIOCompressionMethod)compressionMethod
+                                             error:(NSError **)error
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newIOHandleWithURL:url compressionMethod:compressionMethod error:error];
+}
+
 - (MTLSize)sparseTileSizeWithTextureType:(MTLTextureType)textureType
                              pixelFormat:(MTLPixelFormat)pixelFormat
                              sampleCount:(NSUInteger)sampleCount
@@ -662,6 +710,26 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
                                   numRegions:numRegions];
 }
 
+- (NSUInteger)sparseTileSizeInBytesForSparsePageSize:(MTLSparsePageSize)sparsePageSize
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real sparseTileSizeInBytesForSparsePageSize:sparsePageSize];
+}
+
+- (MTLSize)sparseTileSizeWithTextureType:(MTLTextureType)textureType
+                             pixelFormat:(MTLPixelFormat)pixelFormat
+                             sampleCount:(NSUInteger)sampleCount
+                          sparsePageSize:(MTLSparsePageSize)sparsePageSize
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real sparseTileSizeWithTextureType:textureType
+                                      pixelFormat:pixelFormat
+                                      sampleCount:sampleCount
+                                   sparsePageSize:sparsePageSize];
+}
+
 - (NSUInteger)maxBufferLength API_AVAILABLE(macos(10.14), ios(12.0))
 {
   return self.real.maxBufferLength;
@@ -688,6 +756,13 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   return [self.real sampleTimestamps:cpuTimestamp gpuTimestamp:gpuTimestamp];
 }
 
+- (id<MTLArgumentEncoder>)newArgumentEncoderWithBufferBinding:(id<MTLBufferBinding>)bufferBinding
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newArgumentEncoderWithBufferBinding:bufferBinding];
+}
+
 - (BOOL)supportsCounterSampling:(MTLCounterSamplingPoint)samplingPoint
     API_AVAILABLE(macos(11.0), ios(14.0))
 {
@@ -705,12 +780,10 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   return GetWrapped(self)->supportsDynamicLibraries();
 }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (BOOL)supportsRenderDynamicLibraries API_AVAILABLE(macos(12.0), ios(15.0))
 {
   return GetWrapped(self)->supportsRenderDynamicLibraries();
 }
-#endif
 
 - (nullable id<MTLDynamicLibrary>)newDynamicLibrary:(id<MTLLibrary>)library
                                               error:(NSError **)error
@@ -762,32 +835,38 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
   return [self.real newAccelerationStructureWithDescriptor:descriptor];
 }
 
+- (MTLSizeAndAlign)heapAccelerationStructureSizeAndAlignWithSize:(NSUInteger)size
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real heapAccelerationStructureSizeAndAlignWithSize:size];
+}
+
+- (MTLSizeAndAlign)heapAccelerationStructureSizeAndAlignWithDescriptor:
+    (MTLAccelerationStructureDescriptor *)descriptor API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real heapAccelerationStructureSizeAndAlignWithDescriptor:descriptor];
+}
+
 - (BOOL)supportsFunctionPointers API_AVAILABLE(macos(11.0), ios(14.0))
 {
   return GetWrapped(self)->supportsFunctionPointers();
 }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (BOOL)supportsFunctionPointersFromRender API_AVAILABLE(macos(12.0), ios(15.0))
 {
   return GetWrapped(self)->supportsFunctionPointersFromRender();
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (BOOL)supportsRaytracingFromRender API_AVAILABLE(macos(12.0), ios(15.0))
 {
   return GetWrapped(self)->supportsRaytracingFromRender();
 }
-#endif
 
-// Treat as if the API is available from SDK 12.0
-// It is marked as available from SDK 11.0, however it was not present in SDK 11.1 MTLDevice.h
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (BOOL)supportsPrimitiveMotionBlur API_AVAILABLE(macos(11.0), ios(14.0))
 {
   return GetWrapped(self)->supportsPrimitiveMotionBlur();
 }
-#endif
 
 @end

--- a/renderdoc/driver/metal/metal_render_command_encoder_bridge.mm
+++ b/renderdoc/driver/metal/metal_render_command_encoder_bridge.mm
@@ -491,6 +491,7 @@
   return [self.real setStencilStoreActionOptions:storeActionOptions];
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectBytes:(const void *)bytes
                 length:(NSUInteger)length
                atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
@@ -498,7 +499,9 @@
   METAL_NOT_HOOKED();
   return [self.real setObjectBytes:bytes length:length atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectBuffer:(nullable id<MTLBuffer>)buffer
                  offset:(NSUInteger)offset
                 atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
@@ -506,14 +509,18 @@
   METAL_NOT_HOOKED();
   return [self.real setObjectBuffer:buffer offset:offset atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectBufferOffset:(NSUInteger)offset
                       atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setObjectBufferOffset:offset atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectBuffers:(const id<MTLBuffer> __nullable[__nonnull])buffers
                  offsets:(const NSUInteger[__nonnull])offsets
                withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
@@ -521,35 +528,45 @@
   METAL_NOT_HOOKED();
   return [self.real setObjectBuffers:buffers offsets:offsets withRange:range];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectTexture:(nullable id<MTLTexture>)texture
                  atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setObjectTexture:texture atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectTextures:(const id<MTLTexture> __nullable[__nonnull])textures
                 withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setObjectTextures:textures withRange:range];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectSamplerState:(nullable id<MTLSamplerState>)sampler
                       atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setObjectSamplerState:sampler atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectSamplerStates:(const id<MTLSamplerState> __nullable[__nonnull])samplers
                      withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setObjectSamplerStates:samplers withRange:range];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectSamplerState:(nullable id<MTLSamplerState>)sampler
                   lodMinClamp:(float)lodMinClamp
                   lodMaxClamp:(float)lodMaxClamp
@@ -561,7 +578,9 @@
                               lodMaxClamp:lodMaxClamp
                                   atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectSamplerStates:(const id<MTLSamplerState> __nullable[__nonnull])samplers
                   lodMinClamps:(const float[__nonnull])lodMinClamps
                   lodMaxClamps:(const float[__nonnull])lodMaxClamps
@@ -573,14 +592,18 @@
                               lodMaxClamps:lodMaxClamps
                                  withRange:range];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setObjectThreadgroupMemoryLength:(NSUInteger)length
                                  atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setObjectThreadgroupMemoryLength:length atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshBytes:(const void *)bytes
               length:(NSUInteger)length
              atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
@@ -588,7 +611,9 @@
   METAL_NOT_HOOKED();
   return [self.real setMeshBytes:bytes length:length atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshBuffer:(nullable id<MTLBuffer>)buffer
                offset:(NSUInteger)offset
               atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
@@ -596,14 +621,18 @@
   METAL_NOT_HOOKED();
   return [self.real setMeshBuffer:buffer offset:offset atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshBufferOffset:(NSUInteger)offset
                     atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setMeshBufferOffset:offset atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshBuffers:(const id<MTLBuffer> __nullable[__nonnull])buffers
                offsets:(const NSUInteger[__nonnull])offsets
              withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
@@ -611,35 +640,45 @@
   METAL_NOT_HOOKED();
   return [self.real setMeshBuffers:buffers offsets:offsets withRange:range];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshTexture:(nullable id<MTLTexture>)texture
                atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setMeshTexture:texture atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshTextures:(const id<MTLTexture> __nullable[__nonnull])textures
               withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setMeshTextures:textures withRange:range];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshSamplerState:(nullable id<MTLSamplerState>)sampler
                     atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setMeshSamplerState:sampler atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshSamplerStates:(const id<MTLSamplerState> __nullable[__nonnull])samplers
                    withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setMeshSamplerStates:samplers withRange:range];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshSamplerState:(nullable id<MTLSamplerState>)sampler
                 lodMinClamp:(float)lodMinClamp
                 lodMaxClamp:(float)lodMaxClamp
@@ -651,7 +690,9 @@
                             lodMaxClamp:lodMaxClamp
                                 atIndex:index];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)setMeshSamplerStates:(const id<MTLSamplerState> __nullable[__nonnull])samplers
                 lodMinClamps:(const float[__nonnull])lodMinClamps
                 lodMaxClamps:(const float[__nonnull])lodMaxClamps
@@ -663,7 +704,9 @@
                             lodMaxClamps:lodMaxClamps
                                withRange:range];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)drawMeshThreadgroups:(MTLSize)threadgroupsPerGrid
     threadsPerObjectThreadgroup:(MTLSize)threadsPerObjectThreadgroup
       threadsPerMeshThreadgroup:(MTLSize)threadsPerMeshThreadgroup
@@ -674,7 +717,9 @@
              threadsPerObjectThreadgroup:threadsPerObjectThreadgroup
                threadsPerMeshThreadgroup:threadsPerMeshThreadgroup];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)drawMeshThreads:(MTLSize)threadsPerGrid
     threadsPerObjectThreadgroup:(MTLSize)threadsPerObjectThreadgroup
       threadsPerMeshThreadgroup:(MTLSize)threadsPerMeshThreadgroup
@@ -685,7 +730,9 @@
         threadsPerObjectThreadgroup:threadsPerObjectThreadgroup
           threadsPerMeshThreadgroup:threadsPerMeshThreadgroup];
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (void)drawMeshThreadgroupsWithIndirectBuffer:(id<MTLBuffer>)indirectBuffer
                           indirectBufferOffset:(NSUInteger)indirectBufferOffset
                    threadsPerObjectThreadgroup:(MTLSize)threadsPerObjectThreadgroup
@@ -698,6 +745,7 @@
                                threadsPerObjectThreadgroup:threadsPerObjectThreadgroup
                                  threadsPerMeshThreadgroup:threadsPerMeshThreadgroup];
 }
+#endif
 
 - (void)drawPrimitives:(MTLPrimitiveType)primitiveType
            vertexStart:(NSUInteger)vertexStart

--- a/renderdoc/driver/metal/metal_render_command_encoder_bridge.mm
+++ b/renderdoc/driver/metal/metal_render_command_encoder_bridge.mm
@@ -63,7 +63,7 @@
 }
 
 // MTLCommandEncoder : based on the protocol defined in
-// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLCommandEncoder.h
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLCommandEncoder.h
 
 - (id<MTLDevice>)device
 {
@@ -191,16 +191,13 @@
                                  withRange:range];
 }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setVertexVisibleFunctionTable:(nullable id<MTLVisibleFunctionTable>)functionTable
                         atBufferIndex:(NSUInteger)bufferIndex API_AVAILABLE(macos(12.0), ios(15.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setVertexVisibleFunctionTable:functionTable atBufferIndex:bufferIndex];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setVertexVisibleFunctionTables:
             (const id<MTLVisibleFunctionTable> __nullable[__nonnull])functionTables
                        withBufferRange:(NSRange)range API_AVAILABLE(macos(12.0), ios(15.0))
@@ -208,9 +205,7 @@
   METAL_NOT_HOOKED();
   return [self.real setVertexVisibleFunctionTables:functionTables withBufferRange:range];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setVertexIntersectionFunctionTable:
             (nullable id<MTLIntersectionFunctionTable>)intersectionFunctionTable
                              atBufferIndex:(NSUInteger)bufferIndex
@@ -220,27 +215,22 @@
   return [self.real setVertexIntersectionFunctionTable:intersectionFunctionTable
                                          atBufferIndex:bufferIndex];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setVertexIntersectionFunctionTables:
-            (const id<MTLIntersectionFunctionTable> __nullable[__nonnull])intersectionFunctionTable
+            (const id<MTLIntersectionFunctionTable> __nullable[__nonnull])intersectionFunctionTables
                             withBufferRange:(NSRange)range API_AVAILABLE(macos(12.0), ios(15.0))
 {
   METAL_NOT_HOOKED();
-  return [self.real setVertexIntersectionFunctionTables:intersectionFunctionTable
+  return [self.real setVertexIntersectionFunctionTables:intersectionFunctionTables
                                         withBufferRange:range];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setVertexAccelerationStructure:(nullable id<MTLAccelerationStructure>)accelerationStructure
                          atBufferIndex:(NSUInteger)bufferIndex API_AVAILABLE(macos(12.0), ios(15.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setVertexAccelerationStructure:accelerationStructure atBufferIndex:bufferIndex];
 }
-#endif
 
 - (void)setViewport:(MTLViewport)viewport
 {
@@ -384,16 +374,13 @@
                                    withRange:range];
 }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setFragmentVisibleFunctionTable:(nullable id<MTLVisibleFunctionTable>)functionTable
                           atBufferIndex:(NSUInteger)bufferIndex API_AVAILABLE(macos(12.0), ios(15.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setFragmentVisibleFunctionTable:functionTable atBufferIndex:bufferIndex];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setFragmentVisibleFunctionTables:
             (const id<MTLVisibleFunctionTable> __nullable[__nonnull])functionTables
                          withBufferRange:(NSRange)range API_AVAILABLE(macos(12.0), ios(15.0))
@@ -401,9 +388,7 @@
   METAL_NOT_HOOKED();
   return [self.real setFragmentVisibleFunctionTables:functionTables withBufferRange:range];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setFragmentIntersectionFunctionTable:
             (nullable id<MTLIntersectionFunctionTable>)intersectionFunctionTable
                                atBufferIndex:(NSUInteger)bufferIndex
@@ -413,20 +398,16 @@
   return [self.real setFragmentIntersectionFunctionTable:intersectionFunctionTable
                                            atBufferIndex:bufferIndex];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setFragmentIntersectionFunctionTables:
-            (const id<MTLIntersectionFunctionTable> __nullable[__nonnull])intersectionFunctionTable
+            (const id<MTLIntersectionFunctionTable> __nullable[__nonnull])intersectionFunctionTables
                               withBufferRange:(NSRange)range API_AVAILABLE(macos(12.0), ios(15.0))
 {
   METAL_NOT_HOOKED();
-  return [self.real setFragmentIntersectionFunctionTables:intersectionFunctionTable
+  return [self.real setFragmentIntersectionFunctionTables:intersectionFunctionTables
                                           withBufferRange:range];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setFragmentAccelerationStructure:(nullable id<MTLAccelerationStructure>)accelerationStructure
                            atBufferIndex:(NSUInteger)bufferIndex
     API_AVAILABLE(macos(12.0), ios(15.0))
@@ -435,7 +416,6 @@
   return
       [self.real setFragmentAccelerationStructure:accelerationStructure atBufferIndex:bufferIndex];
 }
-#endif
 
 - (void)setBlendColorRed:(float)red green:(float)green blue:(float)blue alpha:(float)alpha
 {
@@ -509,6 +489,214 @@
 {
   METAL_NOT_HOOKED();
   return [self.real setStencilStoreActionOptions:storeActionOptions];
+}
+
+- (void)setObjectBytes:(const void *)bytes
+                length:(NSUInteger)length
+               atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectBytes:bytes length:length atIndex:index];
+}
+
+- (void)setObjectBuffer:(nullable id<MTLBuffer>)buffer
+                 offset:(NSUInteger)offset
+                atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectBuffer:buffer offset:offset atIndex:index];
+}
+
+- (void)setObjectBufferOffset:(NSUInteger)offset
+                      atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectBufferOffset:offset atIndex:index];
+}
+
+- (void)setObjectBuffers:(const id<MTLBuffer> __nullable[__nonnull])buffers
+                 offsets:(const NSUInteger[__nonnull])offsets
+               withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectBuffers:buffers offsets:offsets withRange:range];
+}
+
+- (void)setObjectTexture:(nullable id<MTLTexture>)texture
+                 atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectTexture:texture atIndex:index];
+}
+
+- (void)setObjectTextures:(const id<MTLTexture> __nullable[__nonnull])textures
+                withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectTextures:textures withRange:range];
+}
+
+- (void)setObjectSamplerState:(nullable id<MTLSamplerState>)sampler
+                      atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectSamplerState:sampler atIndex:index];
+}
+
+- (void)setObjectSamplerStates:(const id<MTLSamplerState> __nullable[__nonnull])samplers
+                     withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectSamplerStates:samplers withRange:range];
+}
+
+- (void)setObjectSamplerState:(nullable id<MTLSamplerState>)sampler
+                  lodMinClamp:(float)lodMinClamp
+                  lodMaxClamp:(float)lodMaxClamp
+                      atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectSamplerState:sampler
+                              lodMinClamp:lodMinClamp
+                              lodMaxClamp:lodMaxClamp
+                                  atIndex:index];
+}
+
+- (void)setObjectSamplerStates:(const id<MTLSamplerState> __nullable[__nonnull])samplers
+                  lodMinClamps:(const float[__nonnull])lodMinClamps
+                  lodMaxClamps:(const float[__nonnull])lodMaxClamps
+                     withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectSamplerStates:samplers
+                              lodMinClamps:lodMinClamps
+                              lodMaxClamps:lodMaxClamps
+                                 withRange:range];
+}
+
+- (void)setObjectThreadgroupMemoryLength:(NSUInteger)length
+                                 atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setObjectThreadgroupMemoryLength:length atIndex:index];
+}
+
+- (void)setMeshBytes:(const void *)bytes
+              length:(NSUInteger)length
+             atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshBytes:bytes length:length atIndex:index];
+}
+
+- (void)setMeshBuffer:(nullable id<MTLBuffer>)buffer
+               offset:(NSUInteger)offset
+              atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshBuffer:buffer offset:offset atIndex:index];
+}
+
+- (void)setMeshBufferOffset:(NSUInteger)offset
+                    atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshBufferOffset:offset atIndex:index];
+}
+
+- (void)setMeshBuffers:(const id<MTLBuffer> __nullable[__nonnull])buffers
+               offsets:(const NSUInteger[__nonnull])offsets
+             withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshBuffers:buffers offsets:offsets withRange:range];
+}
+
+- (void)setMeshTexture:(nullable id<MTLTexture>)texture
+               atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshTexture:texture atIndex:index];
+}
+
+- (void)setMeshTextures:(const id<MTLTexture> __nullable[__nonnull])textures
+              withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshTextures:textures withRange:range];
+}
+
+- (void)setMeshSamplerState:(nullable id<MTLSamplerState>)sampler
+                    atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshSamplerState:sampler atIndex:index];
+}
+
+- (void)setMeshSamplerStates:(const id<MTLSamplerState> __nullable[__nonnull])samplers
+                   withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshSamplerStates:samplers withRange:range];
+}
+
+- (void)setMeshSamplerState:(nullable id<MTLSamplerState>)sampler
+                lodMinClamp:(float)lodMinClamp
+                lodMaxClamp:(float)lodMaxClamp
+                    atIndex:(NSUInteger)index API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshSamplerState:sampler
+                            lodMinClamp:lodMinClamp
+                            lodMaxClamp:lodMaxClamp
+                                atIndex:index];
+}
+
+- (void)setMeshSamplerStates:(const id<MTLSamplerState> __nullable[__nonnull])samplers
+                lodMinClamps:(const float[__nonnull])lodMinClamps
+                lodMaxClamps:(const float[__nonnull])lodMaxClamps
+                   withRange:(NSRange)range API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real setMeshSamplerStates:samplers
+                            lodMinClamps:lodMinClamps
+                            lodMaxClamps:lodMaxClamps
+                               withRange:range];
+}
+
+- (void)drawMeshThreadgroups:(MTLSize)threadgroupsPerGrid
+    threadsPerObjectThreadgroup:(MTLSize)threadsPerObjectThreadgroup
+      threadsPerMeshThreadgroup:(MTLSize)threadsPerMeshThreadgroup
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real drawMeshThreadgroups:threadgroupsPerGrid
+             threadsPerObjectThreadgroup:threadsPerObjectThreadgroup
+               threadsPerMeshThreadgroup:threadsPerMeshThreadgroup];
+}
+
+- (void)drawMeshThreads:(MTLSize)threadsPerGrid
+    threadsPerObjectThreadgroup:(MTLSize)threadsPerObjectThreadgroup
+      threadsPerMeshThreadgroup:(MTLSize)threadsPerMeshThreadgroup
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real drawMeshThreads:threadsPerGrid
+        threadsPerObjectThreadgroup:threadsPerObjectThreadgroup
+          threadsPerMeshThreadgroup:threadsPerMeshThreadgroup];
+}
+
+- (void)drawMeshThreadgroupsWithIndirectBuffer:(id<MTLBuffer>)indirectBuffer
+                          indirectBufferOffset:(NSUInteger)indirectBufferOffset
+                   threadsPerObjectThreadgroup:(MTLSize)threadsPerObjectThreadgroup
+                     threadsPerMeshThreadgroup:(MTLSize)threadsPerMeshThreadgroup
+    API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real drawMeshThreadgroupsWithIndirectBuffer:indirectBuffer
+                                      indirectBufferOffset:indirectBufferOffset
+                               threadsPerObjectThreadgroup:threadsPerObjectThreadgroup
+                                 threadsPerMeshThreadgroup:threadsPerMeshThreadgroup];
 }
 
 - (void)drawPrimitives:(MTLPrimitiveType)primitiveType
@@ -829,25 +1017,20 @@
                                withRange:range];
 }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setTileVisibleFunctionTable:(nullable id<MTLVisibleFunctionTable>)functionTable
                       atBufferIndex:(NSUInteger)bufferIndex API_AVAILABLE(macos(12.0), ios(15.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setTileVisibleFunctionTable:functionTable atBufferIndex:bufferIndex];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setTileVisibleFunctionTables:(const id<MTLVisibleFunctionTable> __nullable[__nonnull])functionTables
                      withBufferRange:(NSRange)range API_AVAILABLE(macos(12.0), ios(15.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setTileVisibleFunctionTables:functionTables withBufferRange:range];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setTileIntersectionFunctionTable:
             (nullable id<MTLIntersectionFunctionTable>)intersectionFunctionTable
                            atBufferIndex:(NSUInteger)bufferIndex
@@ -857,9 +1040,7 @@
   return [self.real setTileIntersectionFunctionTable:intersectionFunctionTable
                                        atBufferIndex:bufferIndex];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setTileIntersectionFunctionTables:
             (const id<MTLIntersectionFunctionTable> __nullable[__nonnull])intersectionFunctionTable
                           withBufferRange:(NSRange)range API_AVAILABLE(macos(12.0), ios(15.0))
@@ -868,16 +1049,13 @@
   return
       [self.real setTileIntersectionFunctionTables:intersectionFunctionTable withBufferRange:range];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (void)setTileAccelerationStructure:(nullable id<MTLAccelerationStructure>)accelerationStructure
                        atBufferIndex:(NSUInteger)bufferIndex API_AVAILABLE(macos(12.0), ios(15.0))
 {
   METAL_NOT_HOOKED();
   return [self.real setTileAccelerationStructure:accelerationStructure atBufferIndex:bufferIndex];
 }
-#endif
 
 - (void)dispatchThreadsPerTile:(MTLSize)threadsPerTile
     API_AVAILABLE(macos(11.0), macCatalyst(14.0), ios(11.0), tvos(14.5))
@@ -976,7 +1154,7 @@
 - (void)memoryBarrierWithScope:(MTLBarrierScope)scope
                    afterStages:(MTLRenderStages)after
                   beforeStages:(MTLRenderStages)before
-    API_AVAILABLE(macos(10.14), macCatalyst(13.0))API_UNAVAILABLE(ios)
+    API_AVAILABLE(macos(10.14), macCatalyst(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real memoryBarrierWithScope:scope afterStages:after beforeStages:before];
@@ -986,7 +1164,7 @@
                              count:(NSUInteger)count
                        afterStages:(MTLRenderStages)after
                       beforeStages:(MTLRenderStages)before
-    API_AVAILABLE(macos(10.14), macCatalyst(13.0))API_UNAVAILABLE(ios)
+    API_AVAILABLE(macos(10.14), macCatalyst(13.0), ios(16.0))
 {
   METAL_NOT_HOOKED();
   return [self.real memoryBarrierWithResources:resources

--- a/renderdoc/driver/metal/metal_render_pipeline_state_bridge.mm
+++ b/renderdoc/driver/metal/metal_render_pipeline_state_bridge.mm
@@ -104,35 +104,47 @@
   return self.real.supportIndirectCommandBuffers;
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (NSUInteger)maxTotalThreadsPerObjectThreadgroup API_AVAILABLE(macos(13.0), ios(16.0))
 {
   return self.real.maxTotalThreadsPerObjectThreadgroup;
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (NSUInteger)maxTotalThreadsPerMeshThreadgroup API_AVAILABLE(macos(13.0), ios(16.0))
 {
   return self.real.maxTotalThreadsPerMeshThreadgroup;
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (NSUInteger)objectThreadExecutionWidth API_AVAILABLE(macos(13.0), ios(16.0))
 {
   return self.real.objectThreadExecutionWidth;
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (NSUInteger)meshThreadExecutionWidth API_AVAILABLE(macos(13.0), ios(16.0))
 {
   return self.real.meshThreadExecutionWidth;
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (NSUInteger)maxTotalThreadgroupsPerMeshGrid API_AVAILABLE(macos(13.0), ios(16.0))
 {
   return self.real.maxTotalThreadgroupsPerMeshGrid;
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (MTLResourceID)gpuResourceID API_AVAILABLE(macos(13.0), ios(16.0))
 {
   return self.real.gpuResourceID;
 }
+#endif
 
 - (nullable id<MTLFunctionHandle>)functionHandleWithFunction:(id<MTLFunction>)function
                                                        stage:(MTLRenderStages)stage

--- a/renderdoc/driver/metal/metal_render_pipeline_state_bridge.mm
+++ b/renderdoc/driver/metal/metal_render_pipeline_state_bridge.mm
@@ -63,7 +63,7 @@
 }
 
 // MTLRenderPipelineState : based on the protocol defined in
-// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLRenderPipeline.h
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLRenderPipeline.h
 
 - (nullable NSString *)label
 {
@@ -104,7 +104,36 @@
   return self.real.supportIndirectCommandBuffers;
 }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
+- (NSUInteger)maxTotalThreadsPerObjectThreadgroup API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  return self.real.maxTotalThreadsPerObjectThreadgroup;
+}
+
+- (NSUInteger)maxTotalThreadsPerMeshThreadgroup API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  return self.real.maxTotalThreadsPerMeshThreadgroup;
+}
+
+- (NSUInteger)objectThreadExecutionWidth API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  return self.real.objectThreadExecutionWidth;
+}
+
+- (NSUInteger)meshThreadExecutionWidth API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  return self.real.meshThreadExecutionWidth;
+}
+
+- (NSUInteger)maxTotalThreadgroupsPerMeshGrid API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  return self.real.maxTotalThreadgroupsPerMeshGrid;
+}
+
+- (MTLResourceID)gpuResourceID API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  return self.real.gpuResourceID;
+}
+
 - (nullable id<MTLFunctionHandle>)functionHandleWithFunction:(id<MTLFunction>)function
                                                        stage:(MTLRenderStages)stage
     API_AVAILABLE(macos(12.0), ios(15.0))
@@ -112,9 +141,7 @@
   METAL_NOT_HOOKED();
   return [self.real functionHandleWithFunction:function stage:stage];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (nullable id<MTLVisibleFunctionTable>)newVisibleFunctionTableWithDescriptor:
                                             (MTLVisibleFunctionTableDescriptor *__nonnull)descriptor
                                                                         stage:(MTLRenderStages)stage
@@ -123,9 +150,7 @@
   METAL_NOT_HOOKED();
   return [self.real newVisibleFunctionTableWithDescriptor:descriptor stage:stage];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (nullable id<MTLIntersectionFunctionTable>)
 newIntersectionFunctionTableWithDescriptor:(MTLIntersectionFunctionTableDescriptor *_Nonnull)descriptor
                                      stage:(MTLRenderStages)stage
@@ -134,9 +159,7 @@ newIntersectionFunctionTableWithDescriptor:(MTLIntersectionFunctionTableDescript
   METAL_NOT_HOOKED();
   return [self.real newIntersectionFunctionTableWithDescriptor:descriptor stage:stage];
 }
-#endif
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (nullable id<MTLRenderPipelineState>)
 newRenderPipelineStateWithAdditionalBinaryFunctions:
     (nonnull MTLRenderPipelineFunctionsDescriptor *)additionalBinaryFunctions
@@ -147,6 +170,5 @@ newRenderPipelineStateWithAdditionalBinaryFunctions:
   return [self.real newRenderPipelineStateWithAdditionalBinaryFunctions:additionalBinaryFunctions
                                                                   error:error];
 }
-#endif
 
 @end

--- a/renderdoc/driver/metal/metal_texture_bridge.mm
+++ b/renderdoc/driver/metal/metal_texture_bridge.mm
@@ -63,7 +63,7 @@
 }
 
 // MTLResource : based on the protocol defined in
-// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLResource.h
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLResource.h
 
 - (nullable NSString *)label
 {
@@ -258,6 +258,16 @@
 - (BOOL)allowGPUOptimizedContents API_AVAILABLE(macos(10.14), ios(12.0))
 {
   return self.real.allowGPUOptimizedContents;
+}
+
+- (MTLTextureCompressionType)compressionType API_AVAILABLE(macos(12.5), ios(15.0))
+{
+  return self.real.compressionType;
+}
+
+- (MTLResourceID)gpuResourceID API_AVAILABLE(macos(13.0), ios(16.0))
+{
+  return self.real.gpuResourceID;
 }
 
 - (void)getBytes:(void *)pixelBytes

--- a/renderdoc/driver/metal/metal_texture_bridge.mm
+++ b/renderdoc/driver/metal/metal_texture_bridge.mm
@@ -260,15 +260,19 @@
   return self.real.allowGPUOptimizedContents;
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_5
 - (MTLTextureCompressionType)compressionType API_AVAILABLE(macos(12.5), ios(15.0))
 {
   return self.real.compressionType;
 }
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
 - (MTLResourceID)gpuResourceID API_AVAILABLE(macos(13.0), ios(16.0))
 {
   return self.real.gpuResourceID;
 }
+#endif
 
 - (void)getBytes:(void *)pixelBytes
       bytesPerRow:(NSUInteger)bytesPerRow

--- a/renderdoc/driver/metal/metal_types_bridge.h
+++ b/renderdoc/driver/metal/metal_types_bridge.h
@@ -56,6 +56,10 @@ inline WrappedMTLResource *GetWrapped(id<MTLResource> objC)
 }
 
 // Define Mac SDK versions when compiling with earlier SDKs
-#ifndef __MAC_12_0
-#define __MAC_12_0 120000
+#ifndef __MAC_12_5
+#define __MAC_12_5 120500
+#endif
+
+#ifndef __MAC_13_0
+#define __MAC_13_0 130000
 #endif


### PR DESCRIPTION
## Description

Changes to Metal protocols to support MacOS SDK 13.1
Removed `#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0` guards now the CI can compile MacOS SDK12.0
macos(13.0) guarded using `#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0`
macos(12.5) guarded using `#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_5`