### PR TITLE
Extend depth overlay tests to include shader exported depth

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_replay.h
+++ b/renderdoc/driver/d3d12/d3d12_replay.h
@@ -463,8 +463,8 @@ private:
     ID3D12RootSignature *QuadResolveRootSig = NULL;
     ID3D12PipelineState *QuadResolvePipe[8] = {NULL};
     ID3D12RootSignature *DepthCopyResolveRootSig = NULL;
-    ID3D12PipelineState *DepthResolvePipe[2][5] = {NULL};
-    ID3D12PipelineState *DepthCopyPipe[2][5] = {NULL};
+    ID3D12PipelineState *DepthResolvePipe[2][5] = {};
+    ID3D12PipelineState *DepthCopyPipe[2][5] = {};
 
     ID3D12Resource *Texture = NULL;
     ResourceId resourceId;

--- a/renderdoc/driver/vulkan/vk_replay.h
+++ b/renderdoc/driver/vulkan/vk_replay.h
@@ -670,10 +670,21 @@ private:
     VkPipelineLayout m_QuadResolvePipeLayout = VK_NULL_HANDLE;
     VkPipeline m_QuadResolvePipeline[8] = {VK_NULL_HANDLE};
 
+    VkDescriptorSetLayout m_DepthCopyDescSetLayout = VK_NULL_HANDLE;
+    VkDescriptorSet m_DepthCopyDescSet = VK_NULL_HANDLE;
+    VkPipelineLayout m_DepthCopyPipeLayout = VK_NULL_HANDLE;
+    VkPipeline m_DepthCopyPipeline[2][5];
+
+    VkPipelineLayout m_DepthResolvePipeLayout = VK_NULL_HANDLE;
+    VkPipeline m_DepthResolvePipeline[2][5];
+
     GPUBuffer m_TriSizeUBO;
     VkDescriptorSetLayout m_TriSizeDescSetLayout = VK_NULL_HANDLE;
     VkDescriptorSet m_TriSizeDescSet = VK_NULL_HANDLE;
     VkPipelineLayout m_TriSizePipeLayout = VK_NULL_HANDLE;
+
+    VkSampler m_PointSampler = VK_NULL_HANDLE;
+    VkFormat m_DefaultDepthStencilFormat;
   } m_Overlay;
 
   struct MeshRendering

--- a/renderdoc/driver/vulkan/vk_shader_cache.cpp
+++ b/renderdoc/driver/vulkan/vk_shader_cache.cpp
@@ -131,6 +131,10 @@ static const BuiltinShaderConfig builtinShaders[] = {
     BuiltinShaderConfig(BuiltinShader::DepthBuf2MSFS, EmbeddedResource(glsl_vk_depthbuf2ms_frag),
                         rdcspv::ShaderStage::Fragment,
                         FeatureCheck::SampleShading | FeatureCheck::NonMetalBackend),
+    BuiltinShaderConfig(BuiltinShader::DepthCopyFS, EmbeddedResource(glsl_depth_copy_frag),
+                        rdcspv::ShaderStage::Fragment, FeatureCheck::FragmentStores),
+    BuiltinShaderConfig(BuiltinShader::DepthCopyMSFS, EmbeddedResource(glsl_depth_copyms_frag),
+                        rdcspv::ShaderStage::Fragment, FeatureCheck::FragmentStores),
 };
 
 RDCCOMPILE_ASSERT(ARRAY_COUNT(builtinShaders) == arraydim<BuiltinShader>(),

--- a/renderdoc/driver/vulkan/vk_shader_cache.h
+++ b/renderdoc/driver/vulkan/vk_shader_cache.h
@@ -60,6 +60,8 @@ enum class BuiltinShader
   DepthMS2BufferCS,
   Buffer2MSCS,
   DepthBuf2MSFS,
+  DepthCopyFS,
+  DepthCopyMSFS,
   Count,
 };
 

--- a/util/test/demos/d3d12/d3d12_overlay_test.cpp
+++ b/util/test/demos/d3d12/d3d12_overlay_test.cpp
@@ -83,6 +83,39 @@ float4 main() : SV_Target0
 
 )EOSHADER";
 
+  std::string depthWritePixel = R"EOSHADER(
+
+struct v2f
+{
+	float4 col : COLOR0;
+	float2 uv : TEXCOORD0;
+	float4 pos : SV_POSITION;
+};
+
+struct PixOut
+{
+	float4 colour : SV_Target0;
+	float depth : SV_Depth;
+};
+
+PixOut main(v2f IN)
+{
+  PixOut OUT;
+	OUT.colour  = IN.col;
+  if ((IN.pos.x > 180.0) && (IN.pos.x < 185.0) &&
+      (IN.pos.y > 155.0) && (IN.pos.y < 165.0))
+	{
+		OUT.depth = 0.0;
+	}
+	else
+	{
+		OUT.depth = IN.pos.z;
+	}
+  return OUT;
+}
+
+)EOSHADER";
+
   int main()
   {
     // initialise, create window, create device, etc
@@ -92,6 +125,7 @@ float4 main() : SV_Target0
     ID3DBlobPtr vsblob[3] = {};
     ID3DBlobPtr psblob[3] = {};
     ID3DBlobPtr whitepsblob[3] = {};
+    ID3DBlobPtr depthwritepsblob[3] = {};
 
     {
       int i = 0;
@@ -103,6 +137,7 @@ float4 main() : SV_Target0
         vsblob[i] = Compile(vertexEndPosVert, "main", "vs" + profile);
         psblob[i] = Compile(vertexEndPosPixel, "main", "ps" + profile);
         whitepsblob[i] = Compile(whitePixel, "main", "ps" + profile);
+        depthwritepsblob[i] = Compile(depthWritePixel, "main", "ps" + profile);
         i++;
       }
     }
@@ -192,6 +227,7 @@ float4 main() : SV_Target0
     ID3D12PipelineStatePtr stencilWritePipe[3][countFmts][2];
     ID3D12PipelineStatePtr backgroundPipe[3][countFmts][2];
     ID3D12PipelineStatePtr pipe[3][countFmts][2];
+    ID3D12PipelineStatePtr depthWritePixelShaderPipe[3][countFmts][2];
     ID3D12PipelineStatePtr whitepipe[3];
     ID3D12PipelineStatePtr sampleMaskPipe[3][countFmts];
 
@@ -265,6 +301,13 @@ float4 main() : SV_Target0
         creator.GraphicsDesc.SampleDesc = yesMSAA;
         pipe[i][f][1] = creator;
 
+        creator.PS(depthwritepsblob[i]);
+        creator.GraphicsDesc.SampleDesc = noMSAA;
+        depthWritePixelShaderPipe[i][f][0] = creator;
+        creator.GraphicsDesc.SampleDesc = yesMSAA;
+        depthWritePixelShaderPipe[i][f][1] = creator;
+
+        creator.PS(psblob[i]);
         creator.GraphicsDesc.SampleDesc = yesMSAA;
         sampleMaskPipe[i][f] = creator;
       }
@@ -393,8 +436,9 @@ float4 main() : SV_Target0
             markerName += fmtName;
             setMarker(cmd, markerName);
 
-            cmd->SetPipelineState(pipe[pass][f][is_msaa ? 1 : 0]);
+            cmd->SetPipelineState(depthWritePixelShaderPipe[pass][f][is_msaa ? 1 : 0]);
             cmd->DrawInstanced(24, 1, 9, 0);
+            cmd->SetPipelineState(pipe[pass][f][is_msaa ? 1 : 0]);
 
             if(!is_msaa)
             {

--- a/util/test/demos/gl/gl_overlay_test.cpp
+++ b/util/test/demos/gl/gl_overlay_test.cpp
@@ -85,6 +85,29 @@ void main()
 
 )EOSHADER";
 
+  std::string fragdepthpixel = R"EOSHADER(
+
+in v2f vertIn;
+
+layout(location = 0, index = 0) out vec4 Color;
+
+void main()
+{
+	Color = vertIn.col;
+
+	if ((gl_FragCoord.x > 180.0) && (gl_FragCoord.x < 185.0) &&
+      (gl_FragCoord.y > 135.0) && (gl_FragCoord.y < 145.0))
+	{
+		gl_FragDepth = 0.0;
+	}
+  else
+  {
+		gl_FragDepth = gl_FragCoord.z;
+  }
+}
+
+)EOSHADER";
+
   int main()
   {
     // initialise, create window, create context, etc
@@ -176,6 +199,7 @@ void main()
 
     GLuint program = MakeProgram(common + vertex, common + pixel);
     GLuint whiteprogram = MakeProgram(common + vertex, whitepixel);
+    GLuint fragdepthprogram = MakeProgram(common + vertex, common + fragdepthpixel);
 
     const char *fmtNames[] = {"D24_S8", "D32F_S8", "D16_S0", "D24_S0", "D32F_S0"};
     GLenum fmts[] = {GL_DEPTH24_STENCIL8, GL_DEPTH32F_STENCIL8, GL_DEPTH_COMPONENT16,
@@ -320,7 +344,9 @@ void main()
 
           glEnable(GL_STENCIL_TEST);
           glStencilFunc(GL_GREATER, 0x55, 0xff);
+          glUseProgram(fragdepthprogram);
           glDrawArrays(GL_TRIANGLES, 9, 24);
+          glUseProgram(program);
 
           if(!is_msaa)
           {

--- a/util/test/rdtest/shared/Overlay_Test.py
+++ b/util/test/rdtest/shared/Overlay_Test.py
@@ -195,6 +195,9 @@ class Overlay_Test(rdtest.TestCase):
                         self.check_pixel_value(overlay_id, 200, 65, [0.0, 1.0, 0.0, 1.0], eps=eps)
                         self.check_pixel_value(overlay_id, 200, 79, [0.0, 1.0, 0.0, 1.0], eps=eps)
                         self.check_pixel_value(overlay_id, 200, 93, [0.0, 1.0, 0.0, 1.0], eps=eps)
+
+                        # Shader modified depth (pass)
+                        self.check_pixel_value(overlay_id, 180, 160, [0.0, 1.0, 0.0, 1.0], eps=eps)
                     elif overlay == rd.DebugOverlay.Stencil:
                         self.check_pixel_value(overlay_id, 150, 90, [0.0, 1.0, 0.0, 1.0], eps=eps)
                         # Intersection with different stencil - stencil fail
@@ -587,7 +590,7 @@ class Overlay_Test(rdtest.TestCase):
             eps = 0.001
 
             if has_stencil:
-                self.check_pixel_value(depth_tex, 180, 160, [0.0, 0.0/255.0, 0.0, 1.0], eps=eps)
+                self.check_pixel_value(depth_tex, 170, 160, [0.0, 0.0/255.0, 0.0, 1.0], eps=eps)
                 self.check_pixel_value(depth_tex, 160, 135, [0.9, 85.0/255.0, 0.0, 1.0], eps=eps)
                 self.check_pixel_value(depth_tex, 160, 165, [0.0, 0.0/255.0, 0.0, 1.0], eps=eps)
                 self.check_pixel_value(depth_tex, 250, 150, [0.5, 85.0/255.0, 0.0, 1.0], eps=eps)


### PR DESCRIPTION
## Description

Extend the depth overlay tests to support Issue 2858

This is the final PR in the sequence of PRs which all together complete the implementation of the feature.
This final PR extends the automated overlay tests `GL_Overlay_Test`, `D3D11_Overlay_Test`, `D3D12_Overlay_Test`, `VK_Overlay_Test`. The tests have been extended to use a pixel shader to write out depth 0.0 for a small rectangle just bottom-left of the centre.

This also includes a minor tweak to the D3D12 overlay initialisation code based on a compile error from clang on similar code used in the Vulkan overlay initialisation.

## Testing
- Windows `GL_Overlay_Test`, `D3D11_Overlay_Test`, `D3D12_Overlay_Test`, `VK_Overlay_Test`.
- Linux `GL_Overlay_Test`, `VK_Overlay_Test`.

