### PR TITLE
When loading a layout close any orphaned windows

### DIFF
--- a/qrenderdoc/3rdparty/toolwindowmanager/ToolWindowManager.cpp
+++ b/qrenderdoc/3rdparty/toolwindowmanager/ToolWindowManager.cpp
@@ -162,7 +162,7 @@ void ToolWindowManager::addToolWindows(QList<QWidget *> toolWindows,
     }
     if(m_toolWindows.contains(toolWindow))
     {
-      qWarning("this tool window has already been added");
+      qWarning() << "this tool window has already been added" << toolWindow->objectName();
       continue;
     }
     toolWindow->hide();
@@ -198,7 +198,7 @@ void ToolWindowManager::moveToolWindows(QList<QWidget *> toolWindows,
   {
     if(!m_toolWindows.contains(toolWindow))
     {
-      qWarning("unknown tool window");
+      qWarning() << "unknown tool window:" << (toolWindow ? toolWindow->objectName() : QString());
       return;
     }
     ToolWindowManagerWrapper *oldWrapper = wrapperOf(toolWindow);
@@ -474,7 +474,7 @@ void ToolWindowManager::removeToolWindow(QWidget *toolWindow, bool allowCloseAlr
 {
   if(!m_toolWindows.contains(toolWindow))
   {
-    qWarning("unknown tool window");
+    qWarning() << "unknown tool window:" << (toolWindow ? toolWindow->objectName() : QString());
     return;
   }
 
@@ -483,7 +483,8 @@ void ToolWindowManager::removeToolWindow(QWidget *toolWindow, bool allowCloseAlr
 
   if(!manager)
   {
-    qWarning("unknown tool window");
+    qWarning() << "window not child of any tool window"
+               << (toolWindow ? toolWindow->objectName() : QString());
     return;
   }
 
@@ -493,6 +494,11 @@ void ToolWindowManager::removeToolWindow(QWidget *toolWindow, bool allowCloseAlr
       return;
   }
 
+  forceCloseToolWindow(toolWindow);
+}
+
+void ToolWindowManager::forceCloseToolWindow(QWidget *toolWindow)
+{
   moveToolWindow(toolWindow, NoArea);
   m_toolWindows.removeOne(toolWindow);
   m_toolWindowProperties.remove(toolWindow);
@@ -537,7 +543,7 @@ void ToolWindowManager::closeToolWindow(QWidget *toolWindow)
     return;
   }
 
-  qWarning("window not child of any tool window");
+  qWarning() << "window not child of any tool window" << toolWindow->objectName();
 }
 
 void ToolWindowManager::raiseToolWindow(QWidget *toolWindow)
@@ -559,7 +565,7 @@ void ToolWindowManager::raiseToolWindow(QWidget *toolWindow)
   if(area)
     area->setCurrentWidget(toolWindow);
   else
-    qWarning("parent is not a tool window area");
+    qWarning() << "parent is not a tool window area" << toolWindow->objectName();
 }
 
 QWidget *ToolWindowManager::createToolWindow(const QString &objectName)
@@ -681,7 +687,8 @@ void ToolWindowManager::releaseToolWindow(QWidget *toolWindow)
   ToolWindowManagerArea *previousTabWidget = findClosestParent<ToolWindowManagerArea *>(toolWindow);
   if(!previousTabWidget)
   {
-    qWarning("cannot find tab widget for tool window");
+    qWarning() << "cannot find tab widget for tool window:"
+               << (toolWindow ? toolWindow->objectName() : QString());
     return;
   }
   previousTabWidget->removeTab(previousTabWidget->indexOf(toolWindow));
@@ -1466,7 +1473,7 @@ bool ToolWindowManager::allowClose(QWidget *toolWindow)
 {
   if(!m_toolWindows.contains(toolWindow))
   {
-    qWarning("unknown tool window");
+    qWarning() << "unknown tool window:" << (toolWindow ? toolWindow->objectName() : QString());
     return true;
   }
   int methodIndex = toolWindow->metaObject()->indexOfMethod(

--- a/qrenderdoc/3rdparty/toolwindowmanager/ToolWindowManager.h
+++ b/qrenderdoc/3rdparty/toolwindowmanager/ToolWindowManager.h
@@ -250,6 +250,12 @@ public:
   static void raiseToolWindow(QWidget *toolWindow);
 
   /*!
+   * Force close a window, to be used when a toolWindow has become orphaned
+   * (no valid parent)
+   */
+  void forceCloseToolWindow(QWidget *toolWindow);
+
+  /*!
    * \brief saveState
    */
   QVariantMap saveState();

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -3072,6 +3072,7 @@ bool MainWindow::restoreState(QVariantMap &state)
 
 bool MainWindow::SaveLayout(int layout)
 {
+  qInfo() << "SaveLayout " << layout;
   QString path = GetLayoutPath(layout);
 
   QVariantMap state = saveState();
@@ -3087,6 +3088,7 @@ bool MainWindow::SaveLayout(int layout)
 
 bool MainWindow::LoadLayout(int layout)
 {
+  qInfo() << "LoadLayout " << layout;
   QString path = GetLayoutPath(layout);
 
   QFile f(path);

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -3101,7 +3101,20 @@ bool MainWindow::LoadLayout(int layout)
     if(!success)
       return false;
 
-    return restoreState(state);
+    if(restoreState(state))
+    {
+      // Close any windows which have now become orphaned
+      foreach(QWidget *toolWindow, ui->toolWindowManager->toolWindows())
+      {
+        if(ui->toolWindowManager->areaOf(toolWindow) == NULL)
+        {
+          qInfo() << "Manually closing orphaned window " << toolWindow->objectName();
+          ui->toolWindowManager->forceCloseToolWindow(toolWindow);
+        }
+      }
+      return true;
+    }
+    return false;
   }
 
   qInfo() << "Couldn't load layout from " << path << " " << f.errorString();


### PR DESCRIPTION
## Description

### Issue 
1. Default Layout (or any layout) : contains multiple windows but does not contain a specific window ie. `Pipeline State`
1. Layout 1 contains windows which are not in the Default Layout i.e. `Pipeline State` window
1. Load Default Layout
1. Load Layout 1
1. Load Default Layout
1. Now unable to open the `Pipeline State` window because it has become orphaned (no parent) from any tool window manager. Have to restart RenderDoc to be able to open the orphaned windows.

### Discussion
- Another solution to the problem would be to pass a valid default tool area to the `raiseToolWindow` similar to how it is done for `addToolWindow` and use the default tool area if the window has become orphaned.
  - this would required touching all calls to `raiseToolWindow` (approximately 45 instances)
 - The orphaned windows will still be in `m_ToolWindows` so anything iterating over that container and sending events could be sending events to ToolWindows which are not visible.
   - Orphaned windows will not close using `closeToolWindow` API which might lead to invalid ToolWindow's i.e. ToolWindow's referencing a capture that has been closed but the ToolWindow itself became orphaned
   - The extra logging will help to identify if the scenario is happening

### Extra Changes
- Added more logging to help diagnose window manager warnings.
- Added logging for when layouts are saved and loaded to help understand how often that happens when looking at log files from users.

### Testing
Following steps mentioned end up with logs like this and are able to open windows which without the fix had not been able to open.
```
QTRD 224632: [15:24:21]       MainWindow.cpp(3075) - Log     - SaveLayout  0
QTRD 224632: [15:24:25]       MainWindow.cpp(3091) - Log     - LoadLayout  1
QTRD 224632: [15:24:25] ToolWindowManager.cpp(1555) - Warning - area parameter ignored for this type
QTRD 224632: [15:24:25]       MainWindow.cpp(3111) - Log     - Manually closing orphaned window  "capDialog"
QTRD 224632: [15:24:30]       MainWindow.cpp(3091) - Log     - LoadLayout  0
QTRD 224632: [15:24:30] ToolWindowManager.cpp( 879) - Warning - invalid splitter encountered
QTRD 224632: [15:24:30]       MainWindow.cpp(3111) - Log     - Manually closing orphaned window  "meshPreview"
QTRD 224632: [15:24:30]       MainWindow.cpp(3111) - Log     - Manually closing orphaned window  "textureViewer"
```