### PR TITLE
Extend D3D11 Depth Test Overlay

### DIFF
--- a/renderdoc/data/hlsl/depth_copy.hlsl
+++ b/renderdoc/data/hlsl/depth_copy.hlsl
@@ -1,0 +1,42 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2023 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+Texture2D<float2> srcDepth : register(t0);
+
+void RENDERDOC_DepthCopyPS(float4 pos : SV_Position, out float depth : SV_Depth)
+{
+  int2 srcCoord = int2(int(pos.x), int(pos.y));
+  depth = srcDepth.Load(int3(srcCoord, 0)).r;
+}
+
+Texture2DMS<float2> srcDepthMS : register(t0);
+
+void RENDERDOC_DepthCopyMSPS(float4 pos
+                             : SV_Position, uint sample
+                             : SV_SampleIndex, out float depth
+                             : SV_Depth)
+{
+  int2 srcCoord = int2(int(pos.x), int(pos.y));
+  depth = srcDepthMS.Load(srcCoord, sample).r;
+}

--- a/renderdoc/data/renderdoc.rc
+++ b/renderdoc/data/renderdoc.rc
@@ -116,6 +116,7 @@ RESOURCE_texremap_hlsl     TYPE_EMBED   "hlsl/texremap.hlsl"
 RESOURCE_fixedcol_hlsl     TYPE_EMBED   "hlsl/fixedcol.hlsl"
 RESOURCE_shaderdebug_hlsl  TYPE_EMBED   "hlsl/shaderdebug.hlsl"
 RESOURCE_d3d12_pixelhistory_hlsl TYPE_EMBED   "hlsl/d3d12_pixelhistory.hlsl"
+RESOURCE_depth_copy_hlsl   TYPE_EMBED   "hlsl/depth_copy.hlsl"
 
 #ifdef RENDERDOC_BAKED_DXC_SHADERS
 

--- a/renderdoc/data/resource.h
+++ b/renderdoc/data/resource.h
@@ -19,6 +19,7 @@
 #define RESOURCE_fixedcol_hlsl      112
 #define RESOURCE_shaderdebug_hlsl   118
 #define RESOURCE_d3d12_pixelhistory_hlsl  119
+#define RESOURCE_depth_copy_hlsl    120
 
 #define RESOURCE_fixedcol_0_dxbc    113
 #define RESOURCE_fixedcol_1_dxbc    114

--- a/renderdoc/driver/d3d11/d3d11_replay.h
+++ b/renderdoc/driver/d3d11/d3d11_replay.h
@@ -425,8 +425,11 @@ private:
     ID3D11PixelShader *QuadOverdrawPS = NULL;
     ID3D11PixelShader *QOResolvePS = NULL;
     ID3D11PixelShader *TriangleSizePS = NULL;
+    ID3D11PixelShader *DepthCopyPS = NULL;
+    ID3D11PixelShader *DepthCopyMSPS = NULL;
     ID3D11GeometryShader *TriangleSizeGS = NULL;
-
+    ID3D11BlendState *DepthBlendRTMaskZero = NULL;
+    ID3D11DepthStencilState *DepthResolveDS = NULL;
     ID3D11Texture2D *Texture = NULL;
     ResourceId resourceId;
   } m_Overlay;

--- a/renderdoc/renderdoc.vcxproj
+++ b/renderdoc/renderdoc.vcxproj
@@ -731,6 +731,7 @@
     <None Include="data\hlsl\texremap.hlsl" />
     <None Include="data\hlsl\fixedcol.hlsl" />
     <None Include="data\hlsl\shaderdebug.hlsl" />
+    <None Include="data\hlsl\depth_copy.hlsl" />
   </ItemGroup>
   <!-- try to bake shaders needed in DXIL now, in case we won't be able to find a dxc at runtime -->
   <UsingTask TaskName="GetDXCExecutable" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">

--- a/renderdoc/renderdoc.vcxproj.filters
+++ b/renderdoc/renderdoc.vcxproj.filters
@@ -1136,6 +1136,9 @@
     <None Include="data\glsl\depth_copyms.frag">
       <Filter>Resources\glsl</Filter>
     </None>
+    <None Include="data\hlsl\depth_copy.hlsl">
+      <Filter>Resources\hlsl</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="data\renderdoc.rc">


### PR DESCRIPTION
## Description

D3D11 Replay support for Issue [#2858](https://github.com/baldurk/renderdoc/issues/2858)

This is a PR in a sequence of PRs which all together complete the implementation of the feature.
Future PRs will cover replay support for D3D12, Vulkan and extending the automated overlay tests `GL_Overlay_Test`, `D3D11_Overlay_Test`, `D3D12_Overlay_Test`, `VK_Overlay_Test`.

The feature enables supporting shader exported depth for the Depth Test overlay by replaying the draw using the pixel shader from the capture instead of a replacement shader. Depth test passing pixels are identified by using the stencil buffer to generate a stencil mask.

If the depth buffer used for the draw does not have a stencil buffer then a new depth buffer is created with a depth+stencil format and a fullscreen pass is used to copy depth from the original depth buffer to the newly created depth+stencil buffer.
 
#### Changes to existing implementation
- Don't write depth or stencil during the reply of failing pixels
- No need to restore depth-stencil after replay of failing pixels

## Tested on Windows using changes to `D3D11_Overlay_Test`
**The change makes the pixel shader write out depth 0.0 for a small rectangle just bottom-left of the centre**

#### Before (using v1.29) : the rectangle of output depth 0.0 is shown as failing the depth test
Depth Buffer format `D24_S8`
![image](https://github.com/Zorro666/renderdoc/assets/39392/e67f678a-9728-4ea6-876a-ac03c4a218a8)
Depth Buffer format `D32_S8`
![image](https://github.com/Zorro666/renderdoc/assets/39392/7bab3887-31ce-41e2-b9ff-d8026df8837f)
Depth Buffer format `D16` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/6f61b872-19c2-4aae-8883-ca2e3d401ee6)
Depth Buffer format `D32` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/bff2ded8-a7c4-4237-8032-c3b62701e94b)

#### After  : the rectangle of output depth 0.0 is shown as passing the depth test
Depth Buffer format `D24_S8`
![image](https://github.com/Zorro666/renderdoc/assets/39392/2fdcd76b-2457-429d-b18e-9ec98630f3dd)
Depth Buffer format `D32_S8`
![image](https://github.com/Zorro666/renderdoc/assets/39392/4cb0e9e0-ce5d-4044-b77d-353ef416a5ac)
Depth Buffer format `D16` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/fa3a86e2-2fab-4352-93ab-c4f4742850f8)
Depth Buffer format `D32` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/c4f6f80d-c4f7-4539-a75d-4c27fad7bdfa)

