### PR TITLE
Added Support for a UI display option for how to format fields marked as Offsets/Sizes

### DIFF
--- a/docs/python_api/qrenderdoc/config.rst
+++ b/docs/python_api/qrenderdoc/config.rst
@@ -13,6 +13,9 @@ Config
 
 .. autoclass:: qrenderdoc.TimeUnit
   :members:
+
+.. autoclass:: qrenderdoc.OffsetSizeDisplayMode
+  :members:
   
 .. autofunction:: qrenderdoc.ConfigFilePath
 .. autofunction:: qrenderdoc.UnitSuffix

--- a/qrenderdoc/Code/Interface/PersistantConfig.cpp
+++ b/qrenderdoc/Code/Interface/PersistantConfig.cpp
@@ -44,6 +44,18 @@ rdcstr DoStringise(const TimeUnit &el)
   END_ENUM_STRINGISE();
 }
 
+template <>
+rdcstr DoStringise(const OffsetSizeDisplayMode &el)
+{
+  BEGIN_ENUM_STRINGISE(OffsetSizeDisplayMode)
+  {
+    STRINGISE_ENUM_CLASS(Auto);
+    STRINGISE_ENUM_CLASS(Decimal);
+    STRINGISE_ENUM_CLASS(Hexadecimal);
+  }
+  END_ENUM_STRINGISE();
+}
+
 #define JSON_ID "rdocConfigData"
 #define JSON_VER 1
 

--- a/qrenderdoc/Code/Interface/PersistantConfig.h
+++ b/qrenderdoc/Code/Interface/PersistantConfig.h
@@ -373,6 +373,16 @@ DECLARE_REFLECTION_STRUCT(BugReport);
   CONFIG_SETTING_VAL(public, int, int, Formatter_PosExp, 7)                                        \
                                                                                                    \
   DOCUMENT(                                                                                        \
+      "The formatting mode to use for values marked as Offsets or Sizes.\n"                        \
+      "\n"                                                                                         \
+      "E.g. Auto: decimal by default and hexadecimal if above a certain threshold, "               \
+      "Decimal: always use decimal, Hexadecimal: always use hexadecimal."                          \
+      "\n"                                                                                         \
+      "Defaults to ``Auto``.");                                                                    \
+  CONFIG_SETTING_VAL(public, int, OffsetSizeDisplayMode, Formatter_OffsetSizeDisplayMode,          \
+                     OffsetSizeDisplayMode::Auto)                                                  \
+                                                                                                   \
+  DOCUMENT(                                                                                        \
       "The global scale to apply to fonts in the application, expressed as a float.\n"             \
       "\n"                                                                                         \
       "Defaults to ``1.0`` which means 100%.");                                                    \
@@ -528,6 +538,30 @@ DECLARE_REFLECTION_STRUCT(BugReport);
                                                                                                    \
   DOCUMENT("");                                                                                    \
   CONFIG_SETTING(private, QVariantList, rdcarray<RemoteHost>, RemoteHostList)
+
+DOCUMENT(R"(The formatting mode used when displaying fields marked as Offsets or Sizes.
+
+.. data:: Auto
+
+  The data is displayed as decimal values by default and hexadecimal if above a certain threshold.
+
+.. data:: Decimal
+
+  The data is displayed as decimal values.
+
+.. data:: Hexadecimal
+
+  The data is displayed as hexadecimal values.
+)");
+enum class OffsetSizeDisplayMode : int
+{
+  Auto = 0,
+  Decimal,
+  Hexadecimal,
+  Count,
+};
+
+DECLARE_REFLECTION_ENUM(OffsetSizeDisplayMode);
 
 DOCUMENT(R"(The unit that GPU durations are displayed in.
 

--- a/qrenderdoc/Code/QRDUtils.cpp
+++ b/qrenderdoc/Code/QRDUtils.cpp
@@ -1764,6 +1764,11 @@ QVariant SDObject2Variant(const SDObject *obj, bool inlineImportant)
   }
   else
   {
+    Formatter::FormatterFlags flags = Formatter::NoFlags;
+    if((obj->type.flags & SDTypeFlags::OffsetOrSize) ||
+       ((obj->GetParent() && obj->GetParent()->type.flags & SDTypeFlags::OffsetOrSize)))
+      flags = Formatter::OffsetSize;
+
     switch(obj->type.basetype)
     {
       case SDBasic::Chunk:
@@ -1875,7 +1880,9 @@ QVariant SDObject2Variant(const SDObject *obj, bool inlineImportant)
       }
       case SDBasic::Resource:
       case SDBasic::Enum:
-      case SDBasic::UnsignedInteger: param = Formatter::HumanFormat(obj->data.basic.u); break;
+      case SDBasic::UnsignedInteger:
+        param = Formatter::HumanFormat(obj->data.basic.u, flags);
+        break;
       case SDBasic::SignedInteger: param = Formatter::Format(obj->data.basic.i); break;
       case SDBasic::Float: param = Formatter::Format(obj->data.basic.d); break;
       case SDBasic::Boolean: param = (obj->data.basic.b ? lit("True") : lit("False")); break;
@@ -2459,6 +2466,7 @@ QString Formatter::m_DefaultFontFamily;
 QString Formatter::m_DefaultMonoFontFamily;
 float Formatter::m_FixedFontBaseSize = 10.0f;
 QColor Formatter::m_DarkChecker, Formatter::m_LightChecker;
+OffsetSizeDisplayMode Formatter::m_OffsetSizeDisplayMode = OffsetSizeDisplayMode::Auto;
 
 void Formatter::setParams(const PersistantConfig &config)
 {
@@ -2469,6 +2477,8 @@ void Formatter::setParams(const PersistantConfig &config)
 
   m_expNegValue = qPow(10.0, -config.Formatter_NegExp);
   m_expPosValue = qPow(10.0, config.Formatter_PosExp);
+
+  m_OffsetSizeDisplayMode = config.Formatter_OffsetSizeDisplayMode;
 
   if(!m_Font)
   {
@@ -2553,7 +2563,7 @@ QString Formatter::Format(double f, bool)
   return ret;
 }
 
-QString Formatter::HumanFormat(uint64_t u)
+QString Formatter::HumanFormat(uint64_t u, FormatterFlags flags)
 {
   if(u == UINT16_MAX)
     return lit("UINT16_MAX");
@@ -2563,8 +2573,26 @@ QString Formatter::HumanFormat(uint64_t u)
     return lit("UINT64_MAX");
 
   // format as hex when over a certain threshold
-  if(u > 0xffffff)
+  bool displayHex = (u > 0xffffff);
+
+  if(flags & OffsetSize)
+  {
+    switch(m_OffsetSizeDisplayMode)
+    {
+      case OffsetSizeDisplayMode::Hexadecimal: displayHex = true; break;
+      case OffsetSizeDisplayMode::Decimal: displayHex = false; break;
+      default: break;
+    }
+  }
+  if(displayHex)
+  {
+    if(u < UINT32_MAX)
+    {
+      uint32_t u32 = u;
+      return lit("0x") + Format(u32, true);
+    }
     return lit("0x") + Format(u, true);
+  }
 
   return Format(u);
 }
@@ -2989,7 +3017,7 @@ void ShowProgressDialog(QWidget *window, const QString &labelText, ProgressFinis
   // show the dialog
   RDDialog::show(&dialog);
 
-  // signal the thread to exit if somehow we got here without it finishing, then wait for it thread
+  // signal the thread to exit if somehow we got here without it finishing, then wait for the thread
   // to clean itself up
   tickerSemaphore.tryAcquire();
   progressTickerThread.wait();

--- a/qrenderdoc/Code/QRDUtils.h
+++ b/qrenderdoc/Code/QRDUtils.h
@@ -368,13 +368,18 @@ void RegisterMetatypeConversions();
 
 struct Formatter
 {
+  enum FormatterFlags
+  {
+    NoFlags = 0x0,
+    OffsetSize = 0x1,
+  };
   static void setParams(const PersistantConfig &config);
   static void setPalette(QPalette palette);
   static void shutdown();
 
   static QString Format(double f, bool hex = false);
   static QString Format(rdhalf f, bool hex = false) { return Format((float)f, hex); }
-  static QString HumanFormat(uint64_t u);
+  static QString HumanFormat(uint64_t u, FormatterFlags flags);
   static QString Format(uint64_t u, bool hex = false)
   {
     return QFormatStr("%1").arg(u, hex ? 16 : 0, hex ? 16 : 10, QLatin1Char('0')).toUpper();
@@ -432,6 +437,7 @@ private:
   static float m_FontBaseSize, m_FixedFontBaseSize;
   static QString m_DefaultFontFamily, m_DefaultMonoFontFamily;
   static QColor m_DarkChecker, m_LightChecker;
+  static OffsetSizeDisplayMode m_OffsetSizeDisplayMode;
 };
 
 bool SaveToJSON(QVariantMap &data, QIODevice &f, const char *magicIdentifier, uint32_t magicVersion);

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
@@ -146,6 +146,11 @@ SettingsDialog::SettingsDialog(ICaptureContext &ctx, QWidget *parent)
     ui->EventBrowser_TimeUnit->addItem(UnitSuffix((TimeUnit)i));
   }
 
+  for(int i = 0; i < (int)OffsetSizeDisplayMode::Count; i++)
+  {
+    ui->Formatter_OffsetSizeDisplayMode->addItem((ToStr((OffsetSizeDisplayMode)i)));
+  }
+
   ui->pages->clearSelection();
   ui->pages->item(0)->setSelected(true);
   ui->tabWidget->setCurrentIndex(0);
@@ -294,6 +299,8 @@ SettingsDialog::SettingsDialog(ICaptureContext &ctx, QWidget *parent)
   ui->Formatter_MaxFigures->setValue(m_Ctx.Config().Formatter_MaxFigures);
   ui->Formatter_NegExp->setValue(m_Ctx.Config().Formatter_NegExp);
   ui->Formatter_PosExp->setValue(m_Ctx.Config().Formatter_PosExp);
+  ui->Formatter_OffsetSizeDisplayMode->setCurrentIndex(
+      (int)m_Ctx.Config().Formatter_OffsetSizeDisplayMode);
 
   if(!RENDERDOC_CanGlobalHook())
   {
@@ -436,6 +443,21 @@ void SettingsDialog::formatter_valueChanged(int val)
 
   m_Ctx.Config().SetupFormatting();
 
+  m_Ctx.Config().Save();
+}
+
+void SettingsDialog::on_Formatter_OffsetSizeDisplayMode_currentIndexChanged(int index)
+{
+  if(m_Init)
+    return;
+
+  if(index < 0 || index >= (int)OffsetSizeDisplayMode::Count)
+    return;
+
+  m_Ctx.Config().Formatter_OffsetSizeDisplayMode =
+      (OffsetSizeDisplayMode)(ui->Formatter_OffsetSizeDisplayMode->currentIndex());
+
+  m_Ctx.Config().SetupFormatting();
   m_Ctx.Config().Save();
 }
 

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.h
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.h
@@ -116,6 +116,7 @@ private slots:
 
   // manual slots
   void formatter_valueChanged(int value);
+  void on_Formatter_OffsetSizeDisplayMode_currentIndexChanged(int index);
 
   void on_analyticsDescribeLabel_linkActivated(const QString &link);
 

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
@@ -287,6 +287,23 @@ e.g. 1000 * 10 = 1e4</string>
            </widget>
           </item>
           <item row="10" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="toolTip">
+             <string>Formatting mode to use for fields marked as a byte offset or a byte size</string>
+            </property>
+            <property name="text">
+             <string>Offset or size fields format mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+            <widget class="QComboBox" name="Formatter_OffsetSizeDisplayMode">
+              <property name="toolTip">
+                <string>Auto: decimal by default and hexadecimal if above a certain threshold, Decimal: always use decimal, Hexadecimal: always use hexadecimal.</string>
+              </property>
+            </widget>
+          </item>
+          <item row="11" column="0">
            <widget class="QLabel" name="label_5">
             <property name="toolTip">
              <string>Changes the directory where capture files are saved after being created, until saved manually or deleted.
@@ -298,7 +315,7 @@ Defaults to %TEMP%.</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="0">
+          <item row="12" column="0">
            <widget class="QLineEdit" name="tempDirectory">
             <property name="toolTip">
              <string>Changes the directory where capture files are saved after being created, until saved manually or deleted.
@@ -307,7 +324,7 @@ Defaults to %TEMP%.</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="1">
+          <item row="12" column="1">
            <widget class="QPushButton" name="browseTempCaptureDirectory">
             <property name="toolTip">
              <string>Changes the directory where capture files are saved after being created, until saved manually or deleted.
@@ -319,7 +336,7 @@ Defaults to %TEMP%.</string>
             </property>
            </widget>
           </item>
-          <item row="12" column="0">
+          <item row="13" column="0">
            <widget class="QLabel" name="label_6">
             <property name="toolTip">
              <string>Changes the default directory for the save dialog when saving capture files.
@@ -331,7 +348,7 @@ Defaults to blank, which follows system default behaviour.</string>
             </property>
            </widget>
           </item>
-          <item row="13" column="0">
+          <item row="14" column="0">
            <widget class="QLineEdit" name="saveDirectory">
             <property name="toolTip">
              <string>Changes the default directory for the save dialog when saving capture files.
@@ -340,7 +357,7 @@ Defaults to blank, which follows system default behaviour.</string>
             </property>
            </widget>
           </item>
-          <item row="13" column="1">
+          <item row="14" column="1">
            <widget class="QPushButton" name="browseSaveCaptureDirectory">
             <property name="toolTip">
              <string>Changes the default directory for the save dialog when saving capture files.
@@ -352,7 +369,7 @@ Defaults to blank, which follows system default behaviour.</string>
             </property>
            </widget>
           </item>
-          <item row="14" column="0">
+          <item row="15" column="0">
            <widget class="QLabel" name="globalHookLabel">
             <property name="toolTip">
              <string>Enables functionality on the capture application window that will insert RenderDoc automatically
@@ -367,7 +384,7 @@ Since this is a global system hook it must be used carefully and only when neces
             </property>
            </widget>
           </item>
-          <item row="14" column="1">
+          <item row="15" column="1">
            <widget class="QCheckBox" name="AllowGlobalHook">
             <property name="toolTip">
              <string>Enables functionality on the capture application window that will insert RenderDoc automatically
@@ -382,7 +399,7 @@ Since this is a global system hook it must be used carefully and only when neces
             </property>
            </widget>
           </item>
-          <item row="15" column="0">
+          <item row="16" column="0">
            <widget class="QLabel" name="injectProcLabel">
             <property name="toolTip">
              <string>Enables the ability to inject into processes on windows.
@@ -396,7 +413,7 @@ program should be launched through RenderDoc via the Launch Process panel.</stri
             </property>
            </widget>
           </item>
-          <item row="15" column="1">
+          <item row="16" column="1">
            <widget class="QCheckBox" name="AllowProcessInject">
             <property name="toolTip">
              <string>Enables the ability to inject into processes on windows.
@@ -410,7 +427,7 @@ program should be launched through RenderDoc via the Launch Process panel.</stri
             </property>
            </widget>
           </item>
-          <item row="16" column="0">
+          <item row="17" column="0">
            <widget class="QLabel" name="label_8">
             <property name="toolTip">
              <string>Allows RenderDoc to phone home to https://renderdoc.org to anonymously check for new versions.</string>
@@ -420,7 +437,7 @@ program should be launched through RenderDoc via the Launch Process panel.</stri
             </property>
            </widget>
           </item>
-          <item row="16" column="1">
+          <item row="17" column="1">
            <widget class="QCheckBox" name="CheckUpdate_AllowChecks">
             <property name="toolTip">
              <string>Allows RenderDoc to phone home to https://renderdoc.org to anonymously check for new versions.</string>
@@ -430,7 +447,7 @@ program should be launched through RenderDoc via the Launch Process panel.</stri
             </property>
            </widget>
           </item>
-          <item row="17" column="0">
+          <item row="18" column="0">
            <widget class="QLabel" name="label_10">
             <property name="toolTip">
              <string>If a capture is marked as being created on a significantly different system (different OS or platform)
@@ -443,7 +460,7 @@ This option overrides that and will always replay locally if the local context i
             </property>
            </widget>
           </item>
-          <item row="17" column="1">
+          <item row="18" column="1">
            <widget class="QCheckBox" name="AlwaysReplayLocally">
             <property name="toolTip">
              <string>If a capture is marked as being created on a significantly different system (different OS or platform)
@@ -456,7 +473,7 @@ This option overrides that and will always replay locally if the local context i
             </property>
            </widget>
           </item>
-          <item row="18" column="1">
+          <item row="19" column="1">
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>

--- a/renderdoc/api/replay/structured_data.h
+++ b/renderdoc/api/replay/structured_data.h
@@ -164,6 +164,11 @@ DOCUMENT(R"(Bitfield flags that could be applied to a type.
 
   Indicates that some children are marked as hidden. This can be important for cases where the
   number of children is important.
+
+.. data:: OffsetOrSize
+
+  Special flag to indicate that this type will be used as a byte offset or byte size, which is used to 
+  control the formatting mode when the value is displayed in the UI.
 )");
 enum class SDTypeFlags : uint32_t
 {
@@ -177,6 +182,7 @@ enum class SDTypeFlags : uint32_t
   Important = 0x40,
   ImportantChildren = 0x80,
   HiddenChildren = 0x100,
+  OffsetOrSize = 0x200,
 };
 
 BITMASK_OPERATORS(SDTypeFlags);

--- a/renderdoc/core/sparse_page_table.cpp
+++ b/renderdoc/core/sparse_page_table.cpp
@@ -913,7 +913,7 @@ template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, Sparse::Page &el)
 {
   SERIALISE_MEMBER(memory);
-  SERIALISE_MEMBER(offset);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
 }
 
 template <typename SerialiserType>
@@ -927,9 +927,9 @@ template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, Sparse::MipTail &el)
 {
   SERIALISE_MEMBER(firstMip);
-  SERIALISE_MEMBER(byteOffset);
-  SERIALISE_MEMBER(byteStride);
-  SERIALISE_MEMBER(totalPackedByteSize);
+  SERIALISE_MEMBER(byteOffset).OffsetOrSize();
+  SERIALISE_MEMBER(byteStride).OffsetOrSize();
+  SERIALISE_MEMBER(totalPackedByteSize).OffsetOrSize();
   SERIALISE_MEMBER(mappings);
 }
 
@@ -939,7 +939,7 @@ void DoSerialise(SerialiserType &ser, Sparse::PageTable &el)
   SERIALISE_MEMBER(m_TextureDim);
   SERIALISE_MEMBER(m_MipCount);
   SERIALISE_MEMBER(m_ArraySize);
-  SERIALISE_MEMBER(m_PageByteSize);
+  SERIALISE_MEMBER(m_PageByteSize).OffsetOrSize();
   SERIALISE_MEMBER(m_PageTexelSize);
   SERIALISE_MEMBER(m_Subresources);
   SERIALISE_MEMBER(m_MipTail);

--- a/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
@@ -448,8 +448,8 @@ bool WrappedID3D11DeviceContext::Serialise_IASetVertexBuffers(SerialiserType &se
   SERIALISE_ELEMENT(StartSlot).Important();
   SERIALISE_ELEMENT(NumBuffers);
   SERIALISE_ELEMENT_ARRAY(ppVertexBuffers, NumBuffers).Important();
-  SERIALISE_ELEMENT_ARRAY(pStrides, NumBuffers);
-  SERIALISE_ELEMENT_ARRAY(pOffsets, NumBuffers);
+  SERIALISE_ELEMENT_ARRAY(pStrides, NumBuffers).OffsetOrSize();
+  SERIALISE_ELEMENT_ARRAY(pOffsets, NumBuffers).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -523,7 +523,7 @@ bool WrappedID3D11DeviceContext::Serialise_IASetIndexBuffer(SerialiserType &ser,
 {
   SERIALISE_ELEMENT(pIndexBuffer).Important();
   SERIALISE_ELEMENT(Format);
-  SERIALISE_ELEMENT(Offset);
+  SERIALISE_ELEMENT(Offset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -2184,7 +2184,7 @@ bool WrappedID3D11DeviceContext::Serialise_SOSetTargets(SerialiserType &ser, UIN
 {
   SERIALISE_ELEMENT(NumBuffers);
   SERIALISE_ELEMENT_ARRAY(ppSOTargets, NumBuffers).Important();
-  SERIALISE_ELEMENT_ARRAY(pOffsets, NumBuffers);
+  SERIALISE_ELEMENT_ARRAY(pOffsets, NumBuffers).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -4268,7 +4268,7 @@ bool WrappedID3D11DeviceContext::Serialise_DrawIndexedInstancedIndirect(Serialis
                                                                         UINT AlignedByteOffsetForArgs)
 {
   SERIALISE_ELEMENT(pBufferForArgs).Important();
-  SERIALISE_ELEMENT(AlignedByteOffsetForArgs);
+  SERIALISE_ELEMENT(AlignedByteOffsetForArgs).OffsetOrSize();
 
   Serialise_DebugMessages(GET_SERIALISER);
 
@@ -4403,7 +4403,7 @@ bool WrappedID3D11DeviceContext::Serialise_DrawInstancedIndirect(SerialiserType 
                                                                  UINT AlignedByteOffsetForArgs)
 {
   SERIALISE_ELEMENT(pBufferForArgs).Important();
-  SERIALISE_ELEMENT(AlignedByteOffsetForArgs);
+  SERIALISE_ELEMENT(AlignedByteOffsetForArgs).OffsetOrSize();
 
   Serialise_DebugMessages(GET_SERIALISER);
 
@@ -5115,7 +5115,7 @@ bool WrappedID3D11DeviceContext::Serialise_DispatchIndirect(SerialiserType &ser,
                                                             UINT AlignedByteOffsetForArgs)
 {
   SERIALISE_ELEMENT(pBufferForArgs).Important();
-  SERIALISE_ELEMENT(AlignedByteOffsetForArgs);
+  SERIALISE_ELEMENT(AlignedByteOffsetForArgs).OffsetOrSize();
 
   Serialise_DebugMessages(GET_SERIALISER);
 
@@ -6263,7 +6263,7 @@ bool WrappedID3D11DeviceContext::Serialise_CopyStructureCount(SerialiserType &se
                                                               ID3D11UnorderedAccessView *pSrcView)
 {
   SERIALISE_ELEMENT(pDstBuffer).Important();
-  SERIALISE_ELEMENT(DstAlignedByteOffset);
+  SERIALISE_ELEMENT(DstAlignedByteOffset).OffsetOrSize();
   SERIALISE_ELEMENT(pSrcView).Important();
 
   SERIALISE_CHECK_READ_ERRORS();
@@ -7931,8 +7931,8 @@ bool WrappedID3D11DeviceContext::Serialise_Unmap(SerialiserType &ser, ID3D11Reso
     SERIALISE_ELEMENT(intercept.MapType).Named("MapType"_lit);
     SERIALISE_ELEMENT_TYPED(D3D11_MAP_FLAG, intercept.MapFlags).Named("MapFlags"_lit);
 
-    SERIALISE_ELEMENT(diffStart).Named("Byte offset to start of written data"_lit);
-    SERIALISE_ELEMENT(diffEnd).Named("Byte offset to end of written data"_lit);
+    SERIALISE_ELEMENT(diffStart).Named("Byte offset to start of written data"_lit).OffsetOrSize();
+    SERIALISE_ELEMENT(diffEnd).Named("Byte offset to end of written data"_lit).OffsetOrSize();
 
     SERIALISE_ELEMENT_ARRAY(MapWrittenData, len).Important();
 

--- a/renderdoc/driver/d3d11/d3d11_device_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device_wrap.cpp
@@ -1315,7 +1315,7 @@ bool WrappedID3D11Device::Serialise_CreateInputLayout(
   SERIALISE_ELEMENT_ARRAY(pInputElementDescs, NumElements).Important();
   SERIALISE_ELEMENT(NumElements);
   SERIALISE_ELEMENT_ARRAY(pShaderBytecodeWithInputSignature, BytecodeLength_);
-  SERIALISE_ELEMENT_LOCAL(BytecodeLength, uint64_t(BytecodeLength_));
+  SERIALISE_ELEMENT_LOCAL(BytecodeLength, uint64_t(BytecodeLength_)).OffsetOrSize();
   SERIALISE_ELEMENT_LOCAL(pInputLayout, GetIDForDeviceChild(*ppInputLayout))
       .TypedAs("ID3D11InputLayout *"_lit);
 
@@ -1693,7 +1693,7 @@ bool WrappedID3D11Device::Serialise_CreateGeometryShaderWithStreamOutput(
   SERIALISE_ELEMENT_LOCAL(BytecodeLength, uint64_t(BytecodeLength_));
   SERIALISE_ELEMENT_ARRAY(pSODeclaration, NumEntries).Important();
   SERIALISE_ELEMENT(NumEntries);
-  SERIALISE_ELEMENT_ARRAY(pBufferStrides, NumStrides);
+  SERIALISE_ELEMENT_ARRAY(pBufferStrides, NumStrides).OffsetOrSize();
   SERIALISE_ELEMENT(NumStrides);
   SERIALISE_ELEMENT(RasterizedStream);
   SERIALISE_ELEMENT(pClassLinkage);

--- a/renderdoc/driver/d3d11/d3d11_renderstate.cpp
+++ b/renderdoc/driver/d3d11/d3d11_renderstate.cpp
@@ -1263,11 +1263,11 @@ void DoSerialise(SerialiserType &ser, D3D11RenderState::InputAssembler &el)
   SERIALISE_MEMBER(Layout);
   SERIALISE_MEMBER(Topo);
   SERIALISE_MEMBER(VBs);
-  SERIALISE_MEMBER(Strides);
-  SERIALISE_MEMBER(Offsets);
+  SERIALISE_MEMBER(Strides).OffsetOrSize();
+  SERIALISE_MEMBER(Offsets).OffsetOrSize();
   SERIALISE_MEMBER(IndexBuffer);
   SERIALISE_MEMBER(IndexFormat);
-  SERIALISE_MEMBER(IndexOffset);
+  SERIALISE_MEMBER(IndexOffset).OffsetOrSize();
 }
 
 template <class SerialiserType>
@@ -1287,7 +1287,7 @@ template <class SerialiserType>
 void DoSerialise(SerialiserType &ser, D3D11RenderState::StreamOut &el)
 {
   SERIALISE_MEMBER(Buffers);
-  SERIALISE_MEMBER(Offsets);
+  SERIALISE_MEMBER(Offsets).OffsetOrSize();
 }
 
 template <class SerialiserType>

--- a/renderdoc/driver/d3d11/d3d11_serialise.cpp
+++ b/renderdoc/driver/d3d11/d3d11_serialise.cpp
@@ -737,7 +737,7 @@ void DoSerialise(SerialiserType &ser, D3D11_INPUT_ELEMENT_DESC &el)
   SERIALISE_MEMBER(SemanticIndex).Important();
   SERIALISE_MEMBER(Format).Important();
   SERIALISE_MEMBER(InputSlot);
-  SERIALISE_MEMBER(AlignedByteOffset);
+  SERIALISE_MEMBER(AlignedByteOffset).OffsetOrSize();
   SERIALISE_MEMBER(InputSlotClass);
   SERIALISE_MEMBER(InstanceDataStepRate);
 }

--- a/renderdoc/driver/d3d12/d3d12_command_list1_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list1_wrap.cpp
@@ -34,9 +34,9 @@ bool WrappedID3D12GraphicsCommandList::Serialise_AtomicCopyBufferUINT(
   ID3D12GraphicsCommandList1 *pCommandList = this;
   SERIALISE_ELEMENT(pCommandList);
   SERIALISE_ELEMENT(pDstBuffer).Important();
-  SERIALISE_ELEMENT(DstOffset);
+  SERIALISE_ELEMENT(DstOffset).OffsetOrSize();
   SERIALISE_ELEMENT(pSrcBuffer).Important();
-  SERIALISE_ELEMENT(SrcOffset);
+  SERIALISE_ELEMENT(SrcOffset).OffsetOrSize();
   SERIALISE_ELEMENT(Dependencies);
   SERIALISE_ELEMENT_ARRAY(ppDependentResources, Dependencies);
   SERIALISE_ELEMENT_ARRAY(pDependentSubresourceRanges, Dependencies);
@@ -147,9 +147,9 @@ bool WrappedID3D12GraphicsCommandList::Serialise_AtomicCopyBufferUINT64(
   ID3D12GraphicsCommandList1 *pCommandList = this;
   SERIALISE_ELEMENT(pCommandList);
   SERIALISE_ELEMENT(pDstBuffer).Important();
-  SERIALISE_ELEMENT(DstOffset);
+  SERIALISE_ELEMENT(DstOffset).OffsetOrSize();
   SERIALISE_ELEMENT(pSrcBuffer).Important();
-  SERIALISE_ELEMENT(SrcOffset);
+  SERIALISE_ELEMENT(SrcOffset).OffsetOrSize();
   SERIALISE_ELEMENT(Dependencies);
   SERIALISE_ELEMENT_ARRAY(ppDependentResources, Dependencies);
   SERIALISE_ELEMENT_ARRAY(pDependentSubresourceRanges, Dependencies);

--- a/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
@@ -3928,9 +3928,9 @@ bool WrappedID3D12GraphicsCommandList::Serialise_ExecuteIndirect(
   SERIALISE_ELEMENT(pCommandSignature).Important();
   SERIALISE_ELEMENT(MaxCommandCount).Important();
   SERIALISE_ELEMENT(pArgumentBuffer).Important();
-  SERIALISE_ELEMENT(ArgumentBufferOffset);
+  SERIALISE_ELEMENT(ArgumentBufferOffset).OffsetOrSize();
   SERIALISE_ELEMENT(pCountBuffer);
-  SERIALISE_ELEMENT(CountBufferOffset);
+  SERIALISE_ELEMENT(CountBufferOffset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -4744,10 +4744,10 @@ bool WrappedID3D12GraphicsCommandList::Serialise_CopyBufferRegion(SerialiserType
   ID3D12GraphicsCommandList *pCommandList = this;
   SERIALISE_ELEMENT(pCommandList);
   SERIALISE_ELEMENT(pDstBuffer).Important();
-  SERIALISE_ELEMENT(DstOffset);
+  SERIALISE_ELEMENT(DstOffset).OffsetOrSize();
   SERIALISE_ELEMENT(pSrcBuffer).Important();
-  SERIALISE_ELEMENT(SrcOffset);
-  SERIALISE_ELEMENT(NumBytes);
+  SERIALISE_ELEMENT(SrcOffset).OffsetOrSize();
+  SERIALISE_ELEMENT(NumBytes).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -5151,7 +5151,7 @@ bool WrappedID3D12GraphicsCommandList::Serialise_CopyTiles(
   SERIALISE_ELEMENT_LOCAL(TileRegionStartCoordinate, *pTileRegionStartCoordinate);
   SERIALISE_ELEMENT_LOCAL(TileRegionSize, *pTileRegionSize);
   SERIALISE_ELEMENT(pBuffer).Important();
-  SERIALISE_ELEMENT(BufferStartOffsetInBytes);
+  SERIALISE_ELEMENT(BufferStartOffsetInBytes).OffsetOrSize();
   SERIALISE_ELEMENT(Flags);
 
   SERIALISE_CHECK_READ_ERRORS();

--- a/renderdoc/driver/d3d12/d3d12_device_rescreate_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_rescreate_wrap.cpp
@@ -666,7 +666,7 @@ bool WrappedID3D12Device::Serialise_CreatePlacedResource(
     void **ppvResource)
 {
   SERIALISE_ELEMENT(pHeap).Important();
-  SERIALISE_ELEMENT(HeapOffset);
+  SERIALISE_ELEMENT(HeapOffset).OffsetOrSize();
   SERIALISE_ELEMENT_LOCAL(desc, *pDesc).Named("pDesc"_lit).Important();
   SERIALISE_ELEMENT(InitialState);
   SERIALISE_ELEMENT_OPT(pOptimizedClearValue);
@@ -1222,7 +1222,7 @@ bool WrappedID3D12Device::Serialise_CreatePlacedResource1(
     void **ppvResource)
 {
   SERIALISE_ELEMENT(pHeap).Important();
-  SERIALISE_ELEMENT(HeapOffset);
+  SERIALISE_ELEMENT(HeapOffset).OffsetOrSize();
   SERIALISE_ELEMENT_LOCAL(desc, *pDesc).Named("pDesc"_lit).Important();
   SERIALISE_ELEMENT(InitialState);
   SERIALISE_ELEMENT_OPT(pOptimizedClearValue);
@@ -1318,7 +1318,7 @@ bool WrappedID3D12Device::Serialise_CreatePlacedResource2(
     UINT32 NumCastableFormats, const DXGI_FORMAT *pCastableFormats, REFIID riid, void **ppvResource)
 {
   SERIALISE_ELEMENT(pHeap).Important();
-  SERIALISE_ELEMENT(HeapOffset);
+  SERIALISE_ELEMENT(HeapOffset).OffsetOrSize();
   SERIALISE_ELEMENT_LOCAL(desc, *pDesc).Named("pDesc"_lit).Important();
   SERIALISE_ELEMENT(InitialLayout);
   SERIALISE_ELEMENT_OPT(pOptimizedClearValue);

--- a/renderdoc/driver/d3d12/d3d12_serialise.cpp
+++ b/renderdoc/driver/d3d12/d3d12_serialise.cpp
@@ -339,7 +339,7 @@ void DoSerialise(SerialiserType &ser, D3D12BufferLocation &el)
     buffer = rm->GetOriginalID(buffer);
 
   ser.Serialise("Buffer"_lit, buffer).Important();
-  ser.Serialise("Offset"_lit, offs);
+  ser.Serialise("Offset"_lit, offs).OffsetOrSize();
 
   if(ser.IsReading() && !ser.IsStructurising())
   {
@@ -796,7 +796,7 @@ void DoSerialise(SerialiserType &ser, D3D12_INPUT_ELEMENT_DESC &el)
   SERIALISE_MEMBER(SemanticIndex);
   SERIALISE_MEMBER(Format);
   SERIALISE_MEMBER(InputSlot);
-  SERIALISE_MEMBER(AlignedByteOffset);
+  SERIALISE_MEMBER(AlignedByteOffset).OffsetOrSize();
   SERIALISE_MEMBER(InputSlotClass);
   SERIALISE_MEMBER(InstanceDataStepRate);
 }
@@ -845,7 +845,7 @@ void DoSerialise(SerialiserType &ser, D3D12_INDIRECT_ARGUMENT_DESC &el)
 template <class SerialiserType>
 void DoSerialise(SerialiserType &ser, D3D12_COMMAND_SIGNATURE_DESC &el)
 {
-  SERIALISE_MEMBER(ByteStride);
+  SERIALISE_MEMBER(ByteStride).OffsetOrSize();
   SERIALISE_MEMBER(NumArgumentDescs);
   SERIALISE_MEMBER_ARRAY(pArgumentDescs, NumArgumentDescs).Important();
   SERIALISE_MEMBER(NodeMask);
@@ -937,15 +937,15 @@ template <class SerialiserType>
 void DoSerialise(SerialiserType &ser, D3D12_VERTEX_BUFFER_VIEW &el)
 {
   SERIALISE_MEMBER_TYPED(D3D12BufferLocation, BufferLocation).Important();
-  SERIALISE_MEMBER(SizeInBytes);
-  SERIALISE_MEMBER(StrideInBytes);
+  SERIALISE_MEMBER(SizeInBytes).OffsetOrSize();
+  SERIALISE_MEMBER(StrideInBytes).OffsetOrSize();
 }
 
 template <class SerialiserType>
 void DoSerialise(SerialiserType &ser, D3D12_INDEX_BUFFER_VIEW &el)
 {
   SERIALISE_MEMBER_TYPED(D3D12BufferLocation, BufferLocation).Important();
-  SERIALISE_MEMBER(SizeInBytes);
+  SERIALISE_MEMBER(SizeInBytes).OffsetOrSize();
   SERIALISE_MEMBER(Format);
 }
 
@@ -953,7 +953,7 @@ template <class SerialiserType>
 void DoSerialise(SerialiserType &ser, D3D12_STREAM_OUTPUT_BUFFER_VIEW &el)
 {
   SERIALISE_MEMBER_TYPED(D3D12BufferLocation, BufferLocation);
-  SERIALISE_MEMBER(SizeInBytes);
+  SERIALISE_MEMBER(SizeInBytes).OffsetOrSize();
   SERIALISE_MEMBER_TYPED(D3D12BufferLocation, BufferFilledSizeLocation);
 }
 
@@ -969,7 +969,7 @@ void DoSerialise(SerialiserType &ser, D3D12_BUFFER_SRV &el)
 {
   SERIALISE_MEMBER(FirstElement);
   SERIALISE_MEMBER(NumElements);
-  SERIALISE_MEMBER(StructureByteStride);
+  SERIALISE_MEMBER(StructureByteStride).OffsetOrSize();
   SERIALISE_MEMBER(Flags);
 }
 
@@ -1223,8 +1223,8 @@ void DoSerialise(SerialiserType &ser, D3D12_BUFFER_UAV &el)
 {
   SERIALISE_MEMBER(FirstElement);
   SERIALISE_MEMBER(NumElements);
-  SERIALISE_MEMBER(StructureByteStride);
-  SERIALISE_MEMBER(CounterOffsetInBytes);
+  SERIALISE_MEMBER(StructureByteStride).OffsetOrSize();
+  SERIALISE_MEMBER(CounterOffsetInBytes).OffsetOrSize();
   SERIALISE_MEMBER(Flags);
 }
 
@@ -1414,7 +1414,7 @@ void DoSerialise(SerialiserType &ser, D3D12_SUBRESOURCE_FOOTPRINT &el)
 template <class SerialiserType>
 void DoSerialise(SerialiserType &ser, D3D12_PLACED_SUBRESOURCE_FOOTPRINT &el)
 {
-  SERIALISE_MEMBER(Offset);
+  SERIALISE_MEMBER(Offset).OffsetOrSize();
   SERIALISE_MEMBER(Footprint);
 }
 
@@ -1769,7 +1769,7 @@ void DoSerialise(SerialiserType &ser, D3D12_BUFFER_BARRIER &el)
   SERIALISE_MEMBER(AccessBefore);
   SERIALISE_MEMBER(AccessAfter);
   SERIALISE_MEMBER(pResource).Important();
-  SERIALISE_MEMBER(Offset);
+  SERIALISE_MEMBER(Offset).OffsetOrSize();
   SERIALISE_MEMBER(Size);
 }
 

--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -958,9 +958,9 @@ bool WrappedOpenGL::Serialise_glNamedBufferSubDataEXT(SerialiserType &ser, GLuin
                                                       const void *data)
 {
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle)).Important();
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
 
-  SERIALISE_ELEMENT_LOCAL(bytesize, (uint64_t)size);
+  SERIALISE_ELEMENT_LOCAL(bytesize, (uint64_t)size).OffsetOrSize();
   SERIALISE_ELEMENT_ARRAY(data, bytesize).Important();
 
   SERIALISE_CHECK_READ_ERRORS();
@@ -1099,9 +1099,9 @@ bool WrappedOpenGL::Serialise_glNamedCopyBufferSubDataEXT(SerialiserType &ser,
 {
   SERIALISE_ELEMENT_LOCAL(readBuffer, BufferRes(GetCtx(), readBufferHandle)).Important();
   SERIALISE_ELEMENT_LOCAL(writeBuffer, BufferRes(GetCtx(), writeBufferHandle)).Important();
-  SERIALISE_ELEMENT_LOCAL(readOffset, (uint64_t)readOffsetPtr);
-  SERIALISE_ELEMENT_LOCAL(writeOffset, (uint64_t)writeOffsetPtr);
-  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr);
+  SERIALISE_ELEMENT_LOCAL(readOffset, (uint64_t)readOffsetPtr).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(writeOffset, (uint64_t)writeOffsetPtr).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -1432,8 +1432,8 @@ bool WrappedOpenGL::Serialise_glBindBufferRange(SerialiserType &ser, GLenum targ
   SERIALISE_ELEMENT(target).Important();
   SERIALISE_ELEMENT(index).Important();
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle)).Important();
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
-  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -1784,8 +1784,8 @@ bool WrappedOpenGL::Serialise_glBindBuffersRange(SerialiserType &ser, GLenum tar
   SERIALISE_ELEMENT(first).Important();
   SERIALISE_ELEMENT(count);
   SERIALISE_ELEMENT(buffers).Important();
-  SERIALISE_ELEMENT(offsets);
-  SERIALISE_ELEMENT(sizes);
+  SERIALISE_ELEMENT(offsets).OffsetOrSize();
+  SERIALISE_ELEMENT(sizes).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -2052,8 +2052,8 @@ bool WrappedOpenGL::Serialise_glInvalidateBufferSubData(SerialiserType &ser, GLu
                                                         GLintptr offsetPtr, GLsizeiptr lengthPtr)
 {
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle)).Important();
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
-  SERIALISE_ELEMENT_LOCAL(length, (uint64_t)lengthPtr);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(length, (uint64_t)lengthPtr).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -2599,8 +2599,8 @@ bool WrappedOpenGL::Serialise_glUnmapNamedBufferEXT(SerialiserType &ser, GLuint 
     record = GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), bufferHandle));
 
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle));
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)record->Map.offset);
-  SERIALISE_ELEMENT_LOCAL(length, (uint64_t)record->Map.length);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)record->Map.offset).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(length, (uint64_t)record->Map.length).OffsetOrSize();
 
   uint64_t diffStart = 0;
   uint64_t diffEnd = (size_t)length;
@@ -2854,8 +2854,8 @@ bool WrappedOpenGL::Serialise_glFlushMappedNamedBufferRangeEXT(SerialiserType &s
   // see above glMapNamedBufferRangeEXT for high-level explanation of how mapping is handled
 
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle));
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
-  SERIALISE_ELEMENT_LOCAL(length, (uint64_t)lengthPtr);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(length, (uint64_t)lengthPtr).OffsetOrSize();
 
   GLResourceRecord *record = NULL;
 
@@ -3306,8 +3306,8 @@ bool WrappedOpenGL::Serialise_glTransformFeedbackBufferRange(SerialiserType &ser
   SERIALISE_ELEMENT_LOCAL(xfb, FeedbackRes(GetCtx(), xfbHandle));
   SERIALISE_ELEMENT(index);
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle));
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
-  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -3538,11 +3538,11 @@ bool WrappedOpenGL::Serialise_glVertexArrayVertexAttribOffsetEXT(
   SERIALISE_ELEMENT_LOCAL(vaobj, VertexArrayRes(GetCtx(), vaobjHandle));
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle));
   SERIALISE_ELEMENT(index);
-  SERIALISE_ELEMENT(size);
+  SERIALISE_ELEMENT(size).OffsetOrSize();
   SERIALISE_ELEMENT(type);
   SERIALISE_ELEMENT_TYPED(bool, normalized);
-  SERIALISE_ELEMENT(stride);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -3668,10 +3668,10 @@ bool WrappedOpenGL::Serialise_glVertexArrayVertexAttribIOffsetEXT(SerialiserType
   SERIALISE_ELEMENT_LOCAL(vaobj, VertexArrayRes(GetCtx(), vaobjHandle));
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle));
   SERIALISE_ELEMENT(index);
-  SERIALISE_ELEMENT(size);
+  SERIALISE_ELEMENT(size).OffsetOrSize();
   SERIALISE_ELEMENT(type);
-  SERIALISE_ELEMENT(stride);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -3796,10 +3796,10 @@ bool WrappedOpenGL::Serialise_glVertexArrayVertexAttribLOffsetEXT(SerialiserType
   SERIALISE_ELEMENT_LOCAL(vaobj, VertexArrayRes(GetCtx(), vaobjHandle));
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle));
   SERIALISE_ELEMENT(index);
-  SERIALISE_ELEMENT(size);
+  SERIALISE_ELEMENT(size).OffsetOrSize();
   SERIALISE_ELEMENT(type);
-  SERIALISE_ELEMENT(stride);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -4007,10 +4007,10 @@ bool WrappedOpenGL::Serialise_glVertexArrayVertexAttribFormatEXT(SerialiserType 
 {
   SERIALISE_ELEMENT_LOCAL(vaobj, VertexArrayRes(GetCtx(), vaobjHandle));
   SERIALISE_ELEMENT(attribindex);
-  SERIALISE_ELEMENT(size);
+  SERIALISE_ELEMENT(size).OffsetOrSize();
   SERIALISE_ELEMENT(type);
   SERIALISE_ELEMENT_TYPED(bool, normalized);
-  SERIALISE_ELEMENT(relativeoffset);
+  SERIALISE_ELEMENT(relativeoffset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -4100,9 +4100,9 @@ bool WrappedOpenGL::Serialise_glVertexArrayVertexAttribIFormatEXT(SerialiserType
 {
   SERIALISE_ELEMENT_LOCAL(vaobj, VertexArrayRes(GetCtx(), vaobjHandle));
   SERIALISE_ELEMENT(attribindex);
-  SERIALISE_ELEMENT(size);
+  SERIALISE_ELEMENT(size).OffsetOrSize();
   SERIALISE_ELEMENT(type);
-  SERIALISE_ELEMENT(relativeoffset);
+  SERIALISE_ELEMENT(relativeoffset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -4189,9 +4189,9 @@ bool WrappedOpenGL::Serialise_glVertexArrayVertexAttribLFormatEXT(SerialiserType
 {
   SERIALISE_ELEMENT_LOCAL(vaobj, VertexArrayRes(GetCtx(), vaobjHandle));
   SERIALISE_ELEMENT(attribindex);
-  SERIALISE_ELEMENT(size);
+  SERIALISE_ELEMENT(size).OffsetOrSize();
   SERIALISE_ELEMENT(type);
-  SERIALISE_ELEMENT(relativeoffset);
+  SERIALISE_ELEMENT(relativeoffset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -4797,8 +4797,8 @@ bool WrappedOpenGL::Serialise_glVertexArrayBindVertexBufferEXT(SerialiserType &s
   SERIALISE_ELEMENT_LOCAL(vaobj, VertexArrayRes(GetCtx(), vaobjHandle)).Important();
   SERIALISE_ELEMENT(bindingindex).Important();
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle)).Important();
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
-  SERIALISE_ELEMENT(stride);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -4922,8 +4922,8 @@ bool WrappedOpenGL::Serialise_glVertexArrayVertexBuffers(SerialiserType &ser, GL
   SERIALISE_ELEMENT(first).Important();
   SERIALISE_ELEMENT(count);
   SERIALISE_ELEMENT(buffers).Important();
-  SERIALISE_ELEMENT(offsets);
-  SERIALISE_ELEMENT_ARRAY(strides, count);
+  SERIALISE_ELEMENT(offsets).OffsetOrSize();
+  SERIALISE_ELEMENT_ARRAY(strides, count).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 

--- a/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
@@ -487,7 +487,7 @@ void WrappedOpenGL::glDispatchComputeGroupSizeARB(GLuint num_groups_x, GLuint nu
 template <typename SerialiserType>
 bool WrappedOpenGL::Serialise_glDispatchComputeIndirect(SerialiserType &ser, GLintptr indirect)
 {
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important().OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -1206,7 +1206,7 @@ bool WrappedOpenGL::Serialise_glDrawArraysIndirect(SerialiserType &ser, GLenum m
                                                    const void *indirect)
 {
   SERIALISE_ELEMENT_TYPED(GLdrawmode, mode);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important().OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -1518,7 +1518,7 @@ bool WrappedOpenGL::Serialise_glDrawElementsIndirect(SerialiserType &ser, GLenum
 {
   SERIALISE_ELEMENT_TYPED(GLdrawmode, mode);
   SERIALISE_ELEMENT(type);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important().OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -2680,9 +2680,9 @@ bool WrappedOpenGL::Serialise_glMultiDrawArraysIndirect(SerialiserType &ser, GLe
                                                         GLsizei stride)
 {
   SERIALISE_ELEMENT_TYPED(GLdrawmode, mode);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important().OffsetOrSize();
   SERIALISE_ELEMENT(drawcount).Important();
-  SERIALISE_ELEMENT(stride);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -2901,9 +2901,9 @@ bool WrappedOpenGL::Serialise_glMultiDrawElementsIndirect(SerialiserType &ser, G
 {
   SERIALISE_ELEMENT_TYPED(GLdrawmode, mode);
   SERIALISE_ELEMENT(type);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important().OffsetOrSize();
   SERIALISE_ELEMENT(drawcount).Important();
-  SERIALISE_ELEMENT(stride);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -3131,10 +3131,10 @@ bool WrappedOpenGL::Serialise_glMultiDrawArraysIndirectCount(SerialiserType &ser
                                                              GLsizei maxdrawcount, GLsizei stride)
 {
   SERIALISE_ELEMENT_TYPED(GLdrawmode, mode);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important().OffsetOrSize();
   SERIALISE_ELEMENT_LOCAL(drawcount, (uint64_t)drawcountPtr).Important();
   SERIALISE_ELEMENT(maxdrawcount).Important();
-  SERIALISE_ELEMENT(stride);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -3364,10 +3364,10 @@ bool WrappedOpenGL::Serialise_glMultiDrawElementsIndirectCount(SerialiserType &s
 {
   SERIALISE_ELEMENT_TYPED(GLdrawmode, mode);
   SERIALISE_ELEMENT(type);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important();
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)indirect).Important().OffsetOrSize();
   SERIALISE_ELEMENT_LOCAL(drawcount, (uint64_t)drawcountPtr).Important();
   SERIALISE_ELEMENT(maxdrawcount).Important();
-  SERIALISE_ELEMENT(stride);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -4281,8 +4281,8 @@ bool WrappedOpenGL::Serialise_glClearNamedBufferSubDataEXT(SerialiserType &ser, 
 {
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle)).Important();
   SERIALISE_ELEMENT(internalformat);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr);
-  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offsetPtr).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr).OffsetOrSize();
   SERIALISE_ELEMENT(format).Important();
   SERIALISE_ELEMENT(type).Important();
 

--- a/renderdoc/driver/gl/wrappers/gl_interop_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_interop_funcs.cpp
@@ -1307,9 +1307,9 @@ bool WrappedOpenGL::Serialise_glNamedBufferStorageMemEXT(SerialiserType &ser, GL
                                                          GLuint64 offset)
 {
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle));
-  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizeptr);
+  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizeptr).OffsetOrSize();
   SERIALISE_ELEMENT_LOCAL(memory, ExtMemRes(GetCtx(), memoryHandle));
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -1423,7 +1423,7 @@ bool WrappedOpenGL::Serialise_glTextureStorageMem1DEXT(SerialiserType &ser, GLui
   SERIALISE_ELEMENT(internalFormat);
   SERIALISE_ELEMENT(width);
   SERIALISE_ELEMENT_LOCAL(memory, ExtMemRes(GetCtx(), memoryHandle));
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -1532,7 +1532,7 @@ bool WrappedOpenGL::Serialise_glTextureStorageMem2DEXT(SerialiserType &ser, GLui
   SERIALISE_ELEMENT(width);
   SERIALISE_ELEMENT(height);
   SERIALISE_ELEMENT_LOCAL(memory, ExtMemRes(GetCtx(), memoryHandle));
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -1646,7 +1646,7 @@ bool WrappedOpenGL::Serialise_glTextureStorageMem2DMultisampleEXT(
   SERIALISE_ELEMENT(height);
   SERIALISE_ELEMENT_TYPED(bool, fixedSampleLocations);
   SERIALISE_ELEMENT_LOCAL(memory, ExtMemRes(GetCtx(), memoryHandle));
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -1771,7 +1771,7 @@ bool WrappedOpenGL::Serialise_glTextureStorageMem3DEXT(SerialiserType &ser, GLui
   SERIALISE_ELEMENT(height);
   SERIALISE_ELEMENT(depth);
   SERIALISE_ELEMENT_LOCAL(memory, ExtMemRes(GetCtx(), memoryHandle));
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -1885,7 +1885,7 @@ bool WrappedOpenGL::Serialise_glTextureStorageMem3DMultisampleEXT(
   SERIALISE_ELEMENT(depth);
   SERIALISE_ELEMENT_TYPED(bool, fixedSampleLocations);
   SERIALISE_ELEMENT_LOCAL(memory, ExtMemRes(GetCtx(), memoryHandle));
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 

--- a/renderdoc/driver/gl/wrappers/gl_query_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_query_funcs.cpp
@@ -582,7 +582,7 @@ bool WrappedOpenGL::Serialise_glGetQueryBufferObjectui64v(SerialiserType &ser, G
   SERIALISE_ELEMENT_LOCAL(readQuery, QueryRes(GetCtx(), id)).Important();
   SERIALISE_ELEMENT_LOCAL(writeBuffer, BufferRes(GetCtx(), buffer)).Important();
   SERIALISE_ELEMENT(pname);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offset_);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offset_).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -665,7 +665,7 @@ bool WrappedOpenGL::Serialise_glGetQueryBufferObjectuiv(SerialiserType &ser, GLu
   SERIALISE_ELEMENT_LOCAL(readQuery, QueryRes(GetCtx(), id)).Important();
   SERIALISE_ELEMENT_LOCAL(writeBuffer, BufferRes(GetCtx(), buffer)).Important();
   SERIALISE_ELEMENT(pname);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offset_);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offset_).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -748,7 +748,7 @@ bool WrappedOpenGL::Serialise_glGetQueryBufferObjecti64v(SerialiserType &ser, GL
   SERIALISE_ELEMENT_LOCAL(readQuery, QueryRes(GetCtx(), id)).Important();
   SERIALISE_ELEMENT_LOCAL(writeBuffer, BufferRes(GetCtx(), buffer)).Important();
   SERIALISE_ELEMENT(pname);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offset_);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offset_).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -830,7 +830,7 @@ bool WrappedOpenGL::Serialise_glGetQueryBufferObjectiv(SerialiserType &ser, GLui
   SERIALISE_ELEMENT_LOCAL(readQuery, QueryRes(GetCtx(), id)).Important();
   SERIALISE_ELEMENT_LOCAL(writeBuffer, BufferRes(GetCtx(), buffer)).Important();
   SERIALISE_ELEMENT(pname);
-  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offset_);
+  SERIALISE_ELEMENT_LOCAL(offset, (uint64_t)offset_).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 

--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -5498,7 +5498,7 @@ bool WrappedOpenGL::Serialise_glTextureSubImage1DEXT(SerialiserType &ser, GLuint
   else
   {
     UnpackOffset = (uint64_t)pixels;
-    SERIALISE_ELEMENT(UnpackOffset);
+    SERIALISE_ELEMENT(UnpackOffset).OffsetOrSize();
   }
 
   SAFE_DELETE_ARRAY(unpackedPixels);
@@ -5731,7 +5731,7 @@ bool WrappedOpenGL::Serialise_glTextureSubImage2DEXT(SerialiserType &ser, GLuint
   else
   {
     UnpackOffset = (uint64_t)pixels;
-    SERIALISE_ELEMENT(UnpackOffset);
+    SERIALISE_ELEMENT(UnpackOffset).OffsetOrSize();
   }
 
   SAFE_DELETE_ARRAY(unpackedPixels);
@@ -5972,7 +5972,7 @@ bool WrappedOpenGL::Serialise_glTextureSubImage3DEXT(SerialiserType &ser, GLuint
   else
   {
     UnpackOffset = (uint64_t)pixels;
-    SERIALISE_ELEMENT(UnpackOffset);
+    SERIALISE_ELEMENT(UnpackOffset).OffsetOrSize();
   }
 
   SAFE_DELETE_ARRAY(unpackedPixels);
@@ -6213,7 +6213,7 @@ bool WrappedOpenGL::Serialise_glCompressedTextureSubImage1DEXT(SerialiserType &s
   else
   {
     UnpackOffset = (uint64_t)pixels;
-    SERIALISE_ELEMENT(UnpackOffset);
+    SERIALISE_ELEMENT(UnpackOffset).OffsetOrSize();
   }
 
   SAFE_DELETE_ARRAY(unpackedPixels);
@@ -6436,7 +6436,7 @@ bool WrappedOpenGL::Serialise_glCompressedTextureSubImage2DEXT(SerialiserType &s
   else
   {
     UnpackOffset = (uint64_t)pixels;
-    SERIALISE_ELEMENT(UnpackOffset);
+    SERIALISE_ELEMENT(UnpackOffset).OffsetOrSize();
   }
 
   SAFE_DELETE_ARRAY(unpackedPixels);
@@ -6677,7 +6677,7 @@ bool WrappedOpenGL::Serialise_glCompressedTextureSubImage3DEXT(
   else
   {
     UnpackOffset = (uint64_t)pixels;
-    SERIALISE_ELEMENT(UnpackOffset);
+    SERIALISE_ELEMENT(UnpackOffset).OffsetOrSize();
   }
 
   SAFE_DELETE_ARRAY(unpackedPixels);
@@ -6890,8 +6890,8 @@ bool WrappedOpenGL::Serialise_glTextureBufferRangeEXT(SerialiserType &ser, GLuin
   HIDE_ARB_DSA_TARGET();
   SERIALISE_ELEMENT(internalformat);
   SERIALISE_ELEMENT_LOCAL(buffer, BufferRes(GetCtx(), bufferHandle)).Important();
-  SERIALISE_ELEMENT_LOCAL(offs, (uint64_t)offsetPtr);
-  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr);
+  SERIALISE_ELEMENT_LOCAL(offs, (uint64_t)offsetPtr).OffsetOrSize();
+  SERIALISE_ELEMENT_LOCAL(size, (uint64_t)sizePtr).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 

--- a/renderdoc/driver/vulkan/vk_serialise.cpp
+++ b/renderdoc/driver/vulkan/vk_serialise.cpp
@@ -2460,8 +2460,8 @@ void DoSerialise(SerialiserType &ser, VkBufferViewCreateInfo &el)
   SERIALISE_MEMBER_VKFLAGS(VkBufferViewCreateFlags, flags);
   SERIALISE_MEMBER(buffer).Important();
   SERIALISE_MEMBER(format).Important();
-  SERIALISE_MEMBER(offset);
-  SERIALISE_MEMBER(range);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
+  SERIALISE_MEMBER(range).OffsetOrSize();
 }
 
 template <>
@@ -2541,10 +2541,10 @@ void Deserialise(const VkImageViewCreateInfo &el)
 template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, VkSparseMemoryBind &el)
 {
-  SERIALISE_MEMBER(resourceOffset);
-  SERIALISE_MEMBER(size);
+  SERIALISE_MEMBER(resourceOffset).OffsetOrSize();
+  SERIALISE_MEMBER(size).OffsetOrSize();
   SERIALISE_MEMBER(memory);
-  SERIALISE_MEMBER(memoryOffset);
+  SERIALISE_MEMBER(memoryOffset).OffsetOrSize();
   SERIALISE_MEMBER_VKFLAGS(VkSparseMemoryBindFlags, flags);
 }
 
@@ -2580,10 +2580,10 @@ template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, VkSparseImageMemoryBind &el)
 {
   SERIALISE_MEMBER(subresource);
-  SERIALISE_MEMBER(offset);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
   SERIALISE_MEMBER(extent);
   SERIALISE_MEMBER(memory);
-  SERIALISE_MEMBER(memoryOffset);
+  SERIALISE_MEMBER(memoryOffset).OffsetOrSize();
   SERIALISE_MEMBER_VKFLAGS(VkSparseMemoryBindFlags, flags);
 }
 
@@ -2828,7 +2828,7 @@ void DoSerialise(SerialiserType &ser, VkVertexInputAttributeDescription &el)
   SERIALISE_MEMBER(location);
   SERIALISE_MEMBER(binding);
   SERIALISE_MEMBER(format);
-  SERIALISE_MEMBER(offset);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
 }
 
 template <typename SerialiserType>
@@ -3239,14 +3239,14 @@ template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, VkSpecializationMapEntry &el)
 {
   SERIALISE_MEMBER(constantID);
-  SERIALISE_MEMBER(offset);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
   // this was accidentally duplicated - hide it from the UI
   SERIALISE_MEMBER(constantID).Hidden();
 
   // don't serialise size_t, otherwise capture/replay between different bit-ness won't work
   {
     uint64_t size = el.size;
-    ser.Serialise("size"_lit, size);
+    ser.Serialise("size"_lit, size).OffsetOrSize();
     if(ser.IsReading())
       el.size = (size_t)size;
   }
@@ -3388,7 +3388,7 @@ void DoSerialise(SerialiserType &ser, VkMemoryAllocateInfo &el)
   RDCASSERT(ser.IsReading() || el.sType == VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO);
   SerialiseNext(ser, el.sType, el.pNext);
 
-  SERIALISE_MEMBER(allocationSize).Important();
+  SERIALISE_MEMBER(allocationSize).Important().OffsetOrSize();
   SERIALISE_MEMBER(memoryTypeIndex).Important();
 }
 
@@ -3431,8 +3431,8 @@ void DoSerialise(SerialiserType &ser, VkBufferMemoryBarrier &el)
   SERIALISE_MEMBER_TYPED(int32_t, srcQueueFamilyIndex);
   SERIALISE_MEMBER_TYPED(int32_t, dstQueueFamilyIndex);
   SERIALISE_MEMBER(buffer).Important();
-  SERIALISE_MEMBER(offset);
-  SERIALISE_MEMBER(size);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
+  SERIALISE_MEMBER(size).OffsetOrSize();
 }
 
 template <>
@@ -3802,8 +3802,8 @@ void DoSerialise(SerialiserType &ser, VkDescriptorBufferInfo &el)
   OPTIONAL_RESOURCES();
 
   SERIALISE_MEMBER(buffer);
-  SERIALISE_MEMBER(offset);
-  SERIALISE_MEMBER(range);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
+  SERIALISE_MEMBER(range).OffsetOrSize();
 }
 
 template <typename SerialiserType>
@@ -3928,8 +3928,8 @@ template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, VkPushConstantRange &el)
 {
   SERIALISE_MEMBER_VKFLAGS(VkShaderStageFlags, stageFlags);
-  SERIALISE_MEMBER(offset);
-  SERIALISE_MEMBER(size);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
+  SERIALISE_MEMBER(size).OffsetOrSize();
 }
 
 template <typename SerialiserType>
@@ -3994,8 +3994,8 @@ void DoSerialise(SerialiserType &ser, VkMappedMemoryRange &el)
   SerialiseNext(ser, el.sType, el.pNext);
 
   SERIALISE_MEMBER(memory).Important();
-  SERIALISE_MEMBER(offset);
-  SERIALISE_MEMBER(size);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
+  SERIALISE_MEMBER(size).OffsetOrSize();
 }
 
 template <>
@@ -4007,7 +4007,7 @@ void Deserialise(const VkMappedMemoryRange &el)
 template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, VkBufferImageCopy &el)
 {
-  SERIALISE_MEMBER(bufferOffset);
+  SERIALISE_MEMBER(bufferOffset).OffsetOrSize();
   SERIALISE_MEMBER(bufferRowLength);
   SERIALISE_MEMBER(bufferImageHeight);
   SERIALISE_MEMBER(imageSubresource);
@@ -4018,9 +4018,9 @@ void DoSerialise(SerialiserType &ser, VkBufferImageCopy &el)
 template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, VkBufferCopy &el)
 {
-  SERIALISE_MEMBER(srcOffset);
-  SERIALISE_MEMBER(dstOffset);
-  SERIALISE_MEMBER(size);
+  SERIALISE_MEMBER(srcOffset).OffsetOrSize();
+  SERIALISE_MEMBER(dstOffset).OffsetOrSize();
+  SERIALISE_MEMBER(size).OffsetOrSize();
 }
 
 template <typename SerialiserType>
@@ -5126,8 +5126,8 @@ void DoSerialise(SerialiserType &ser, DescriptorSetSlot &el)
     {
       VkDeviceSize offset = el.offset;
       VkDeviceSize range = el.GetRange();
-      SERIALISE_ELEMENT(offset);
-      SERIALISE_ELEMENT(range);
+      SERIALISE_ELEMENT(offset).OffsetOrSize();
+      SERIALISE_ELEMENT(range).OffsetOrSize();
       el.offset = offset;
       el.range = range;
     }
@@ -5313,8 +5313,8 @@ void DoSerialise(SerialiserType &ser, VkDescriptorUpdateTemplateEntry &el)
       offset = el.offset;
       stride = el.stride;
     }
-    ser.Serialise("offset"_lit, offset);
-    ser.Serialise("stride"_lit, stride);
+    ser.Serialise("offset"_lit, offset).OffsetOrSize();
+    ser.Serialise("stride"_lit, stride).OffsetOrSize();
     if(ser.IsReading())
     {
       el.offset = (size_t)offset;
@@ -5324,8 +5324,8 @@ void DoSerialise(SerialiserType &ser, VkDescriptorUpdateTemplateEntry &el)
 #if DISABLED(RDOC_APPLE)
   else
   {
-    SERIALISE_MEMBER(offset);
-    SERIALISE_MEMBER(stride);
+    SERIALISE_MEMBER(offset).OffsetOrSize();
+    SERIALISE_MEMBER(stride).OffsetOrSize();
   }
 #endif
 }
@@ -5379,7 +5379,7 @@ void DoSerialise(SerialiserType &ser, VkBindBufferMemoryInfo &el)
 
   SERIALISE_MEMBER(buffer).Important();
   SERIALISE_MEMBER(memory).Important();
-  SERIALISE_MEMBER(memoryOffset);
+  SERIALISE_MEMBER(memoryOffset).OffsetOrSize();
 }
 
 template <>
@@ -5396,7 +5396,7 @@ void DoSerialise(SerialiserType &ser, VkBindImageMemoryInfo &el)
 
   SERIALISE_MEMBER(image).Important();
   SERIALISE_MEMBER(memory).Important();
-  SERIALISE_MEMBER(memoryOffset);
+  SERIALISE_MEMBER(memoryOffset).OffsetOrSize();
 }
 
 template <>
@@ -7861,9 +7861,9 @@ void DoSerialise(SerialiserType &ser, VkBufferCopy2 &el)
   RDCASSERT(ser.IsReading() || el.sType == VK_STRUCTURE_TYPE_BUFFER_COPY_2);
   SerialiseNext(ser, el.sType, el.pNext);
 
-  SERIALISE_MEMBER(srcOffset);
-  SERIALISE_MEMBER(dstOffset);
-  SERIALISE_MEMBER(size);
+  SERIALISE_MEMBER(srcOffset).OffsetOrSize();
+  SERIALISE_MEMBER(dstOffset).OffsetOrSize();
+  SERIALISE_MEMBER(size).OffsetOrSize();
 }
 
 template <>
@@ -7937,7 +7937,7 @@ void DoSerialise(SerialiserType &ser, VkBufferImageCopy2 &el)
   RDCASSERT(ser.IsReading() || el.sType == VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2);
   SerialiseNext(ser, el.sType, el.pNext);
 
-  SERIALISE_MEMBER(bufferOffset);
+  SERIALISE_MEMBER(bufferOffset).OffsetOrSize();
   SERIALISE_MEMBER(bufferRowLength);
   SERIALISE_MEMBER(bufferImageHeight);
   SERIALISE_MEMBER(imageSubresource);
@@ -10492,8 +10492,8 @@ void DoSerialise(SerialiserType &ser, VkBufferMemoryBarrier2 &el)
   SERIALISE_MEMBER_TYPED(int32_t, srcQueueFamilyIndex);
   SERIALISE_MEMBER_TYPED(int32_t, dstQueueFamilyIndex);
   SERIALISE_MEMBER(buffer).Important();
-  SERIALISE_MEMBER(offset);
-  SERIALISE_MEMBER(size);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
+  SERIALISE_MEMBER(size).OffsetOrSize();
 }
 
 template <>
@@ -11157,7 +11157,7 @@ void DoSerialise(SerialiserType &ser, VkConditionalRenderingBeginInfoEXT &el)
   SerialiseNext(ser, el.sType, el.pNext);
 
   SERIALISE_MEMBER(buffer).Important();
-  SERIALISE_MEMBER(offset);
+  SERIALISE_MEMBER(offset).OffsetOrSize();
   SERIALISE_MEMBER_VKFLAGS(VkConditionalRenderingFlagsEXT, flags);
 }
 

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -3710,9 +3710,9 @@ bool WrappedVulkan::Serialise_vkCmdBindVertexBuffers2(
   SERIALISE_ELEMENT(firstBinding).Important();
   SERIALISE_ELEMENT(bindingCount);
   SERIALISE_ELEMENT_ARRAY(pBuffers, bindingCount).Important();
-  SERIALISE_ELEMENT_ARRAY(pOffsets, bindingCount);
-  SERIALISE_ELEMENT_ARRAY(pSizes, bindingCount);
-  SERIALISE_ELEMENT_ARRAY(pStrides, bindingCount);
+  SERIALISE_ELEMENT_ARRAY(pOffsets, bindingCount).OffsetOrSize();
+  SERIALISE_ELEMENT_ARRAY(pSizes, bindingCount).OffsetOrSize();
+  SERIALISE_ELEMENT_ARRAY(pStrides, bindingCount).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -3817,7 +3817,7 @@ bool WrappedVulkan::Serialise_vkCmdBindIndexBuffer(SerialiserType &ser,
 {
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT(buffer).Important();
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
   SERIALISE_ELEMENT(indexType).Important();
 
   Serialise_DebugMessages(ser);
@@ -4463,8 +4463,8 @@ bool WrappedVulkan::Serialise_vkCmdCopyQueryPoolResults(
   SERIALISE_ELEMENT(firstQuery);
   SERIALISE_ELEMENT(queryCount);
   SERIALISE_ELEMENT(destBuffer).Important();
-  SERIALISE_ELEMENT(destOffset);
-  SERIALISE_ELEMENT(destStride);
+  SERIALISE_ELEMENT(destOffset).OffsetOrSize();
+  SERIALISE_ELEMENT(destStride).OffsetOrSize();
   SERIALISE_ELEMENT_TYPED(VkQueryResultFlagBits, flags).TypedAs("VkQueryResultFlags"_lit);
 
   Serialise_DebugMessages(ser);
@@ -5949,7 +5949,7 @@ bool WrappedVulkan::Serialise_vkCmdWriteBufferMarkerAMD(SerialiserType &ser,
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT(pipelineStage);
   SERIALISE_ELEMENT(dstBuffer).Important();
-  SERIALISE_ELEMENT(dstOffset);
+  SERIALISE_ELEMENT(dstOffset).OffsetOrSize();
   SERIALISE_ELEMENT(marker).Important();
 
   Serialise_DebugMessages(ser);
@@ -6016,7 +6016,7 @@ bool WrappedVulkan::Serialise_vkCmdWriteBufferMarker2AMD(SerialiserType &ser,
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT_TYPED(VkPipelineStageFlagBits2, stage).TypedAs("VkPipelineStageFlags2"_lit);
   SERIALISE_ELEMENT(dstBuffer).Important();
-  SERIALISE_ELEMENT(dstOffset);
+  SERIALISE_ELEMENT(dstOffset).OffsetOrSize();
   SERIALISE_ELEMENT(marker).Important();
 
   Serialise_DebugMessages(ser);
@@ -6340,8 +6340,8 @@ bool WrappedVulkan::Serialise_vkCmdBindTransformFeedbackBuffersEXT(
   SERIALISE_ELEMENT(firstBinding).Important();
   SERIALISE_ELEMENT(bindingCount);
   SERIALISE_ELEMENT_ARRAY(pBuffers, bindingCount).Important();
-  SERIALISE_ELEMENT_ARRAY(pOffsets, bindingCount);
-  SERIALISE_ELEMENT_ARRAY(pSizes, bindingCount);
+  SERIALISE_ELEMENT_ARRAY(pOffsets, bindingCount).OffsetOrSize();
+  SERIALISE_ELEMENT_ARRAY(pSizes, bindingCount).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -6440,7 +6440,7 @@ bool WrappedVulkan::Serialise_vkCmdBeginTransformFeedbackEXT(
   SERIALISE_ELEMENT(firstBuffer).Important();
   SERIALISE_ELEMENT(bufferCount).Important();
   SERIALISE_ELEMENT_ARRAY(pCounterBuffers, bufferCount);
-  SERIALISE_ELEMENT_ARRAY(pCounterBufferOffsets, bufferCount);
+  SERIALISE_ELEMENT_ARRAY(pCounterBufferOffsets, bufferCount).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -6535,7 +6535,7 @@ bool WrappedVulkan::Serialise_vkCmdEndTransformFeedbackEXT(
   SERIALISE_ELEMENT(firstBuffer).Important();
   SERIALISE_ELEMENT(bufferCount).Important();
   SERIALISE_ELEMENT_ARRAY(pCounterBuffers, bufferCount);
-  SERIALISE_ELEMENT_ARRAY(pCounterBufferOffsets, bufferCount);
+  SERIALISE_ELEMENT_ARRAY(pCounterBufferOffsets, bufferCount).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 

--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -343,9 +343,9 @@ bool WrappedVulkan::Serialise_vkCmdDrawIndirect(SerialiserType &ser, VkCommandBu
 {
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT(buffer).Important();
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
   SERIALISE_ELEMENT(count).Important();
-  SERIALISE_ELEMENT(stride);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -751,9 +751,9 @@ bool WrappedVulkan::Serialise_vkCmdDrawIndexedIndirect(SerialiserType &ser,
 {
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT(buffer).Important();
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
   SERIALISE_ELEMENT(count).Important();
-  SERIALISE_ELEMENT(stride);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -1206,7 +1206,7 @@ bool WrappedVulkan::Serialise_vkCmdDispatchIndirect(SerialiserType &ser,
 {
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT(buffer).Important();
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -2053,8 +2053,8 @@ bool WrappedVulkan::Serialise_vkCmdUpdateBuffer(SerialiserType &ser, VkCommandBu
 {
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT(destBuffer).Important();
-  SERIALISE_ELEMENT(destOffset);
-  SERIALISE_ELEMENT(dataSize);
+  SERIALISE_ELEMENT(destOffset).OffsetOrSize();
+  SERIALISE_ELEMENT(dataSize).OffsetOrSize();
 
   // serialise as void* so it goes through as a buffer, not an actual array of integers.
   const void *Data = (const void *)pData;
@@ -2151,8 +2151,8 @@ bool WrappedVulkan::Serialise_vkCmdFillBuffer(SerialiserType &ser, VkCommandBuff
 {
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT(destBuffer).Important();
-  SERIALISE_ELEMENT(destOffset);
-  SERIALISE_ELEMENT(fillSize);
+  SERIALISE_ELEMENT(destOffset).OffsetOrSize();
+  SERIALISE_ELEMENT(fillSize).OffsetOrSize();
   SERIALISE_ELEMENT(data).Important();
 
   Serialise_DebugMessages(ser);
@@ -2738,11 +2738,11 @@ bool WrappedVulkan::Serialise_vkCmdDrawIndirectCount(SerialiserType &ser,
 {
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT(buffer).Important();
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
   SERIALISE_ELEMENT(countBuffer).Important();
-  SERIALISE_ELEMENT(countBufferOffset);
+  SERIALISE_ELEMENT(countBufferOffset).OffsetOrSize();
   SERIALISE_ELEMENT(maxDrawCount).Important();
-  SERIALISE_ELEMENT(stride);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -3085,11 +3085,11 @@ bool WrappedVulkan::Serialise_vkCmdDrawIndexedIndirectCount(
 {
   SERIALISE_ELEMENT(commandBuffer);
   SERIALISE_ELEMENT(buffer).Important();
-  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(offset).OffsetOrSize();
   SERIALISE_ELEMENT(countBuffer).Important();
-  SERIALISE_ELEMENT(countBufferOffset);
+  SERIALISE_ELEMENT(countBufferOffset).OffsetOrSize();
   SERIALISE_ELEMENT(maxDrawCount).Important();
-  SERIALISE_ELEMENT(stride);
+  SERIALISE_ELEMENT(stride).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 
@@ -3437,9 +3437,9 @@ bool WrappedVulkan::Serialise_vkCmdDrawIndirectByteCountEXT(
   SERIALISE_ELEMENT(instanceCount).Important();
   SERIALISE_ELEMENT(firstInstance);
   SERIALISE_ELEMENT(counterBuffer).Important();
-  SERIALISE_ELEMENT(counterBufferOffset);
-  SERIALISE_ELEMENT(counterOffset);
-  SERIALISE_ELEMENT(vertexStride);
+  SERIALISE_ELEMENT(counterBufferOffset).OffsetOrSize();
+  SERIALISE_ELEMENT(counterOffset).OffsetOrSize();
+  SERIALISE_ELEMENT(vertexStride).OffsetOrSize();
 
   Serialise_DebugMessages(ser);
 

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -909,8 +909,8 @@ bool WrappedVulkan::Serialise_vkUnmapMemory(SerialiserType &ser, VkDevice device
     MapData = (byte *)state->cpuReadPtr + MapOffset;
   }
 
-  SERIALISE_ELEMENT(MapOffset);
-  SERIALISE_ELEMENT(MapSize);
+  SERIALISE_ELEMENT(MapOffset).OffsetOrSize();
+  SERIALISE_ELEMENT(MapSize).OffsetOrSize();
 
   bool directStream = true;
 
@@ -1384,7 +1384,7 @@ bool WrappedVulkan::Serialise_vkBindBufferMemory(SerialiserType &ser, VkDevice d
   SERIALISE_ELEMENT(device);
   SERIALISE_ELEMENT(buffer).Important();
   SERIALISE_ELEMENT(memory).Important();
-  SERIALISE_ELEMENT(memoryOffset);
+  SERIALISE_ELEMENT(memoryOffset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 
@@ -1509,7 +1509,7 @@ bool WrappedVulkan::Serialise_vkBindImageMemory(SerialiserType &ser, VkDevice de
   SERIALISE_ELEMENT(device);
   SERIALISE_ELEMENT(image).Important();
   SERIALISE_ELEMENT(memory).Important();
-  SERIALISE_ELEMENT(memoryOffset);
+  SERIALISE_ELEMENT(memoryOffset).OffsetOrSize();
 
   SERIALISE_CHECK_READ_ERRORS();
 

--- a/renderdoc/serialise/serialiser.h
+++ b/renderdoc/serialise/serialiser.h
@@ -1224,6 +1224,19 @@ public:
     return *this;
   }
 
+  Serialiser &OffsetOrSize()
+  {
+    if(ExportStructure() && !m_StructureStack.empty())
+    {
+      SDObject &current = *m_StructureStack.back();
+
+      if(current.NumChildren() > 0)
+        current.GetChild(current.NumChildren() - 1)->type.flags |= SDTypeFlags::OffsetOrSize;
+    }
+
+    return *this;
+  }
+
   // these functions should be used very carefully, they completely disable structured export for
   // anything serialised while internal is set.
   void PushInternal() { m_InternalElement++; }


### PR DESCRIPTION
## Description

Issue [2924](https://github.com/baldurk/renderdoc/issues/2924)

Previously by default, values are displayed using decimal formatting unless they are above a threshold (0xFFFFFF) then they are displayed using hexadecimal formatting.

There is now a UI formatter setting to change this behaviour for fields which have been marked as an Offset/Size type. 
The UI option has three modes: `Auto`, `Decimal`, `Hexadecimal`: 
- `Auto` : behaves as it currently does, decimal by default with hexadecimal when the value is above a threshold
- `Decimal` : always display the value using decimal formatting
- `Hexadecimal` : always display the value using hexadecimal formatting

The new UI option does not affect fields which have **not** been marked as an Offset/Size type.

There is one additional change to existing behaviour when printing using hexadecimal (`Auto` or `Hexadecimal` mode) then for values below `UINT32_MAX` the values are treated as `uint32_t` instead of `uint64_t` (eight leading zero's instead of sixteen leading zero's) e.g.
- Before
`dstOffset 0x0000000001000000`
- After
`dstOffset 0x01000000`

This is an example of a field not marked as an Offset or Size field with a large value, the display does not change for `Auto`, `Decimal`, `Hexadecimal` mode:
- Before
`jakeTest 0x0000000001000000`
- After
`jakeTest 0x01000000`

Done a first pass, reviewing the serialised fields for all APIs to apply mark up for the `OffsetOrSize` field type. The selection criteria was an offset or size which is measured in bytes. This markup can be refined in the future it does not affect the captured data.

## Testing

### Before showing the existing behaviour of the `Auto` formatting mode
- Decimal for values less than or equal to 0xFFFFFF
![image](https://github.com/Zorro666/renderdoc/assets/39392/b5f3c0cc-4e1f-417d-b267-fd4268ca10d5)- Hexadecimal for values above 0xFFFFFF
![image](https://github.com/Zorro666/renderdoc/assets/39392/e1b52e3f-8935-477b-a1fb-166d2babd393)

### After showing the behaviour of the new formatting modes

#### `Auto` formatting mode
- Decimal for values less than or equal to 0xFFFFFF
![image](https://github.com/Zorro666/renderdoc/assets/39392/1d86b856-2549-4930-b73a-878ba206cb9f)- Hexadecimal for values above 0xFFFFFF
![image](https://github.com/Zorro666/renderdoc/assets/39392/012ef451-7002-4f26-b091-38f6b44f97c4)

#### `Decimal` formatting mode
- Decimal for values less than or equal to 0xFFFFFF
![image](https://github.com/Zorro666/renderdoc/assets/39392/776ceb70-77d5-4a9c-92b4-78e562d4e117)- Decimal for values above 0xFFFFFF
![image](https://github.com/Zorro666/renderdoc/assets/39392/f83a7c7b-e7d6-4421-b1c8-c851e8c8969d)

#### `Hexadecimal` formatting mode
- Hexadecimal for values less than or equal to 0xFFFFFF
![image](https://github.com/Zorro666/renderdoc/assets/39392/eb0df7fc-7bc2-4c71-910a-6140a02173cb)- Hexadecimal for values above 0xFFFFFF
![image](https://github.com/Zorro666/renderdoc/assets/39392/63a475e4-4dbb-4e3d-9b9e-85d4d66581e0)
