### PR TITLE
Couple of small fixes: add a link to the buffer view documents, change the buffer viewer error style for dark mode

### DIFF
--- a/docs/how/how_buffer_format.rst
+++ b/docs/how/how_buffer_format.rst
@@ -162,7 +162,7 @@ The buffer format supports annotations on declarations to specify special proper
 Struct definitions support the following annotations:
 
 * ``[[size(number)]]`` or ``[[byte_size(number)]]`` - Forces the struct to be padded up to a given size even if the contents don't require it.
-* ``[[single]]`` or ``[[fixed]]`` - Forces the struct to be considered as a fixed SoA definition, even if in context the buffer viewer may default to AoS. See the below section for more details. Structs with this annotation **may not** be declared as a variable, and should instead be the implicit final struct in a definition.
+* ``[[single]]`` or ``[[fixed]]`` - Forces the struct to be considered as a fixed SoA definition, even if in context the buffer viewer may default to AoS. See :ref:`the below section <aos-soa>` for more details. Structs with this annotation **may not** be declared as a variable, and should instead be the implicit final struct in a definition.
 
 Variable declarations support the following annotations:
 

--- a/qrenderdoc/Widgets/BufferFormatSpecifier.cpp
+++ b/qrenderdoc/Widgets/BufferFormatSpecifier.cpp
@@ -86,7 +86,9 @@ BufferFormatSpecifier::BufferFormatSpecifier(QWidget *parent)
 
   QColor base = formatText->palette().color(QPalette::Base);
 
-  QColor col = QColor::fromHslF(0.0f, 1.0f, qBound(0.1, base.lightnessF(), 0.9));
+  QColor col = IsDarkTheme()
+                   ? QColor::fromHslF(0.0f, 1.0f, qBound(0.1, 1.0f - base.lightnessF(), 0.9))
+                   : QColor::fromHslF(0.0f, 1.0f, qBound(0.1, base.lightnessF(), 0.9));
 
   formatText->styleSetBack(ERROR_STYLE, SCINTILLA_COLOUR(col.red(), col.green(), col.blue()));
 


### PR DESCRIPTION
## Description

- Added a link to "below section" to the buffer viewer struct docs
- In dark mode invert the lightness for the buffer format error style

- Before Buffer Format Error
![image](https://github.com/Zorro666/renderdoc/assets/39392/98abc6f1-235b-4f9a-bfa3-83f14ce72e47)

- After Buffer Format Error
![image](https://github.com/Zorro666/renderdoc/assets/39392/290a868e-8bff-4e61-b9a3-72068ab2686f)


