### PR TITLE
Remove static DXIL::dxcStyleFormatting and DXIL::dxilIdentifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,19 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 100
-    - name: Check commit messages
+    - name: Check commit messages (PR)
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        if git log --oneline | tail -n +2 | head -n 100 | grep -v 76f9176 | cut -d ' ' -f2- | grep -q '.\{73\}'; then
+          (echo -n "::error::";
+           echo "Some commit message summary lines are too long. See CONTRIBUTING.md for more information.";
+           echo "Invalid commits:";
+           echo;
+           git log --oneline | tail -n +2 | head -n 100 | grep -v 76f9176 | cut -d ' ' -f2- | grep '.\{73\}';) | tr '\n' '\001' | sed -e 's#\x01#%0A#g';
+          exit 1;
+        fi
+    - name: Check commit messages (Push)
+      if: ${{ github.event_name == 'push' }}
       run: |
         if git log --oneline | head -n 100 | grep -v 76f9176 | cut -d ' ' -f2- | grep -q '.\{73\}'; then
           (echo -n "::error::";

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -844,6 +844,7 @@ extern bool IsGLES;
   EXT_COMP_CHECK(ARB_texture_buffer_object, OES_texture_buffer)                             \
   EXT_COMP_CHECK(ARB_texture_buffer_range, EXT_texture_buffer)                              \
   EXT_COMP_CHECK(ARB_texture_buffer_range, OES_texture_buffer)                              \
+  EXT_COMP_CHECK(ARB_clip_control, EXT_clip_control)                                        \
   EXT_COMP_CHECK(EXT_framebuffer_sRGB, EXT_sRGB_write_control)
 
 // extensions we know we want to check for are precached, indexd by this enum

--- a/renderdoc/driver/shaders/dxil/dxil_debuginfo.cpp
+++ b/renderdoc/driver/shaders/dxil/dxil_debuginfo.cpp
@@ -323,16 +323,16 @@ rdcstr getOptMetaString(const Metadata *meta)
   return meta ? escapeString(meta->str).c_str() : "\"\"";
 }
 
-rdcstr DIFile::toString() const
+rdcstr DIFile::toString(bool dxcStyleFormatting) const
 {
   return StringFormat::Fmt("!DIFile(filename: %s, directory: %s)", getOptMetaString(file).c_str(),
                            getOptMetaString(dir).c_str());
 }
 
-rdcstr DICompileUnit::toString() const
+rdcstr DICompileUnit::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = StringFormat::Fmt("!DICompileUnit(language: %s, file: %s", ToStr(lang).c_str(),
-                                 file ? file->refString().c_str() : "null");
+                                 file ? file->refString(dxcStyleFormatting).c_str() : "null");
 
   if(producer)
     ret += ", producer: " + escapeString(*producer);
@@ -344,22 +344,22 @@ rdcstr DICompileUnit::toString() const
     ret += ", splitDebugFilename: " + escapeString(*splitDebugFilename);
   ret += StringFormat::Fmt(", emissionKind: %llu", emissionKind);
   if(enums)
-    ret += ", enums: " + enums->refString();
+    ret += ", enums: " + enums->refString(dxcStyleFormatting);
   if(retainedTypes)
-    ret += ", retainedTypes: " + retainedTypes->refString();
+    ret += ", retainedTypes: " + retainedTypes->refString(dxcStyleFormatting);
   if(subprograms)
-    ret += ", subprograms: " + subprograms->refString();
+    ret += ", subprograms: " + subprograms->refString(dxcStyleFormatting);
   if(globals)
-    ret += ", globals: " + globals->refString();
+    ret += ", globals: " + globals->refString(dxcStyleFormatting);
   if(imports)
-    ret += ", imports: " + imports->refString();
+    ret += ", imports: " + imports->refString(dxcStyleFormatting);
 
   ret += ")";
 
   return ret;
 }
 
-rdcstr DIBasicType::toString() const
+rdcstr DIBasicType::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = "!DIBasicType(";
   if(tag != DW_TAG_base_type)
@@ -372,19 +372,19 @@ rdcstr DIBasicType::toString() const
   return ret;
 }
 
-rdcstr DIDerivedType::toString() const
+rdcstr DIDerivedType::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = StringFormat::Fmt("!DIDerivedType(tag: %s", ToStr(tag).c_str());
   if(name)
     ret += StringFormat::Fmt(", name: %s", escapeString(*name).c_str());
   if(scope)
-    ret += StringFormat::Fmt(", scope: %s", scope->refString().c_str());
+    ret += StringFormat::Fmt(", scope: %s", scope->refString(dxcStyleFormatting).c_str());
   if(file)
-    ret += StringFormat::Fmt(", file: %s", file->refString().c_str());
+    ret += StringFormat::Fmt(", file: %s", file->refString(dxcStyleFormatting).c_str());
   if(line)
     ret += StringFormat::Fmt(", line: %llu", line);
   if(base)
-    ret += StringFormat::Fmt(", baseType: %s", base->refString().c_str());
+    ret += StringFormat::Fmt(", baseType: %s", base->refString(dxcStyleFormatting).c_str());
   else
     ret += ", baseType: null";
   if(sizeInBits)
@@ -396,24 +396,24 @@ rdcstr DIDerivedType::toString() const
   if(flags != DIFlagNone)
     ret += StringFormat::Fmt(", flags: %s", ToStr(flags).c_str());
   if(extra)
-    ret += StringFormat::Fmt(", extraData: %s", extra->refString().c_str());
+    ret += StringFormat::Fmt(", extraData: %s", extra->refString(dxcStyleFormatting).c_str());
   ret += ")";
   return ret;
 }
 
-rdcstr DICompositeType::toString() const
+rdcstr DICompositeType::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = StringFormat::Fmt("!DICompositeType(tag: %s", ToStr(tag).c_str());
   if(name)
     ret += StringFormat::Fmt(", name: %s", escapeString(*name).c_str());
   if(scope)
-    ret += StringFormat::Fmt(", scope: %s", scope->refString().c_str());
+    ret += StringFormat::Fmt(", scope: %s", scope->refString(dxcStyleFormatting).c_str());
   if(file)
-    ret += StringFormat::Fmt(", file: %s", file->refString().c_str());
+    ret += StringFormat::Fmt(", file: %s", file->refString(dxcStyleFormatting).c_str());
   if(line)
     ret += StringFormat::Fmt(", line: %llu", line);
   if(base)
-    ret += StringFormat::Fmt(", baseType: %s", base->refString().c_str());
+    ret += StringFormat::Fmt(", baseType: %s", base->refString(dxcStyleFormatting).c_str());
   if(sizeInBits)
     ret += StringFormat::Fmt(", size: %llu", sizeInBits);
   if(alignInBits)
@@ -423,14 +423,15 @@ rdcstr DICompositeType::toString() const
   if(flags != DIFlagNone)
     ret += StringFormat::Fmt(", flags: %s", ToStr(flags).c_str());
   if(elements)
-    ret += StringFormat::Fmt(", elements: %s", elements->refString().c_str());
+    ret += StringFormat::Fmt(", elements: %s", elements->refString(dxcStyleFormatting).c_str());
   if(templateParams)
-    ret += StringFormat::Fmt(", templateParams: %s", templateParams->refString().c_str());
+    ret += StringFormat::Fmt(", templateParams: %s",
+                             templateParams->refString(dxcStyleFormatting).c_str());
   ret += ")";
   return ret;
 }
 
-rdcstr DIEnum::toString() const
+rdcstr DIEnum::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = "!DIEnumerator(";
   ret += StringFormat::Fmt("name: %s", escapeString(*name).c_str());
@@ -439,22 +440,22 @@ rdcstr DIEnum::toString() const
   return ret;
 }
 
-rdcstr DITemplateTypeParameter::toString() const
+rdcstr DITemplateTypeParameter::toString(bool dxcStyleFormatting) const
 {
   return StringFormat::Fmt("!DITemplateTypeParameter(name: %s, type: %s)",
                            escapeString(name ? *name : rdcstr()).c_str(),
-                           type ? type->refString().c_str() : "null");
+                           type ? type->refString(dxcStyleFormatting).c_str() : "null");
 }
 
-rdcstr DITemplateValueParameter::toString() const
+rdcstr DITemplateValueParameter::toString(bool dxcStyleFormatting) const
 {
   return StringFormat::Fmt("!DITemplateValueParameter(name: %s, type: %s, value: %s)",
                            escapeString(name ? *name : rdcstr()).c_str(),
-                           type ? type->refString().c_str() : "null",
-                           value ? value->refString().c_str() : "null");
+                           type ? type->refString(dxcStyleFormatting).c_str() : "null",
+                           value ? value->refString(dxcStyleFormatting).c_str() : "null");
 }
 
-rdcstr DISubprogram::toString() const
+rdcstr DISubprogram::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = "!DISubprogram(";
   if(name)
@@ -462,21 +463,22 @@ rdcstr DISubprogram::toString() const
   if(linkageName)
     ret += StringFormat::Fmt("linkageName: %s, ", escapeString(*linkageName).c_str());
   if(scope)
-    ret += StringFormat::Fmt("scope: %s, ", scope->refString().c_str());
+    ret += StringFormat::Fmt("scope: %s, ", scope->refString(dxcStyleFormatting).c_str());
   if(file)
-    ret += StringFormat::Fmt("file: %s", file->refString().c_str());
+    ret += StringFormat::Fmt("file: %s", file->refString(dxcStyleFormatting).c_str());
   else
     ret += "file: null";
   if(line)
     ret += StringFormat::Fmt(", line: %llu", line);
   if(type)
-    ret += StringFormat::Fmt(", type: %s", type->refString().c_str());
+    ret += StringFormat::Fmt(", type: %s", type->refString(dxcStyleFormatting).c_str());
   ret += StringFormat::Fmt(", isLocal: %s", isLocal ? "true" : "false");
   ret += StringFormat::Fmt(", isDefinition: %s", isDefinition ? "true" : "false");
   if(scopeLine)
     ret += StringFormat::Fmt(", scopeLine: %llu", scopeLine);
   if(containingType)
-    ret += StringFormat::Fmt(", containingType: %s", containingType->refString().c_str());
+    ret += StringFormat::Fmt(", containingType: %s",
+                             containingType->refString(dxcStyleFormatting).c_str());
 
   if(virtuality)
   {
@@ -491,73 +493,74 @@ rdcstr DISubprogram::toString() const
   ret += StringFormat::Fmt(", isOptimized: %s", isOptimized ? "true" : "false");
 
   if(function)
-    ret += StringFormat::Fmt(", function: %s", function->refString().c_str());
+    ret += StringFormat::Fmt(", function: %s", function->refString(dxcStyleFormatting).c_str());
   if(templateParams)
-    ret += StringFormat::Fmt(", templateParams: %s", templateParams->refString().c_str());
+    ret += StringFormat::Fmt(", templateParams: %s",
+                             templateParams->refString(dxcStyleFormatting).c_str());
   if(declaration)
-    ret += StringFormat::Fmt(", declaration: %s", declaration->refString().c_str());
+    ret += StringFormat::Fmt(", declaration: %s", declaration->refString(dxcStyleFormatting).c_str());
   if(variables)
-    ret += StringFormat::Fmt(", variables: %s", variables->refString().c_str());
+    ret += StringFormat::Fmt(", variables: %s", variables->refString(dxcStyleFormatting).c_str());
 
   ret += ")";
   return ret;
 }
 
-rdcstr DISubroutineType::toString() const
+rdcstr DISubroutineType::toString(bool dxcStyleFormatting) const
 {
   return StringFormat::Fmt("!DISubroutineType(types: %s)",
-                           types ? types->refString().c_str() : "null");
+                           types ? types->refString(dxcStyleFormatting).c_str() : "null");
 }
 
-rdcstr DIGlobalVariable::toString() const
+rdcstr DIGlobalVariable::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret =
       StringFormat::Fmt("!DIGlobalVariable(name: %s", escapeString(name ? *name : rdcstr()).c_str());
   if(linkageName)
     ret += StringFormat::Fmt(", linkageName: %s", escapeString(*linkageName).c_str());
   if(scope)
-    ret += StringFormat::Fmt(", scope: %s", scope->refString().c_str());
+    ret += StringFormat::Fmt(", scope: %s", scope->refString(dxcStyleFormatting).c_str());
   if(file)
-    ret += StringFormat::Fmt(", file: %s", file->refString().c_str());
+    ret += StringFormat::Fmt(", file: %s", file->refString(dxcStyleFormatting).c_str());
   else
     ret += ", file: null";
   if(line)
     ret += StringFormat::Fmt(", line: %llu", line);
   if(type)
-    ret += StringFormat::Fmt(", type: %s", type->refString().c_str());
+    ret += StringFormat::Fmt(", type: %s", type->refString(dxcStyleFormatting).c_str());
   ret += StringFormat::Fmt(", isLocal: %s", isLocal ? "true" : "false");
   ret += StringFormat::Fmt(", isDefinition: %s", isDefinition ? "true" : "false");
   if(declaration)
-    ret += StringFormat::Fmt(", declaration: %s", declaration->refString().c_str());
+    ret += StringFormat::Fmt(", declaration: %s", declaration->refString(dxcStyleFormatting).c_str());
   if(variable)
-    ret += StringFormat::Fmt(", variable: %s", variable->refString().c_str());
+    ret += StringFormat::Fmt(", variable: %s", variable->refString(dxcStyleFormatting).c_str());
   ret += ")";
   return ret;
 }
 
-rdcstr DILocalVariable::toString() const
+rdcstr DILocalVariable::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = StringFormat::Fmt("!DILocalVariable(tag: %s, name: %s", ToStr(tag).c_str(),
                                  escapeString(name ? *name : rdcstr()).c_str());
   if(arg || tag != DW_TAG_auto_variable)
     ret += StringFormat::Fmt(", arg: %llu", arg);
   if(scope)
-    ret += StringFormat::Fmt(", scope: %s", scope->refString().c_str());
+    ret += StringFormat::Fmt(", scope: %s", scope->refString(dxcStyleFormatting).c_str());
   else
     ret += ", scope: null";
   if(file)
-    ret += StringFormat::Fmt(", file: %s", file->refString().c_str());
+    ret += StringFormat::Fmt(", file: %s", file->refString(dxcStyleFormatting).c_str());
   if(line)
     ret += StringFormat::Fmt(", line: %llu", line);
   if(type)
-    ret += StringFormat::Fmt(", type: %s", type->refString().c_str());
+    ret += StringFormat::Fmt(", type: %s", type->refString(dxcStyleFormatting).c_str());
   if(flags != DIFlagNone)
     ret += StringFormat::Fmt(", flags: %s", ToStr(flags).c_str());
   ret += ")";
   return ret;
 }
 
-rdcstr DIExpression::toString() const
+rdcstr DIExpression::toString(bool dxcStyleFormatting) const
 {
   if(op == DW_OP_bit_piece)
     return StringFormat::Fmt("!DIExpression(DW_OP_bit_piece, %llu, %llu)",
@@ -580,15 +583,15 @@ rdcstr DIExpression::toString() const
   return ret;
 }
 
-rdcstr DILexicalBlock::toString() const
+rdcstr DILexicalBlock::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = "!DILexicalBlock(";
   if(scope)
-    ret += StringFormat::Fmt("scope: %s", scope->refString().c_str());
+    ret += StringFormat::Fmt("scope: %s", scope->refString(dxcStyleFormatting).c_str());
   else
     ret += "scope: null";
   if(file)
-    ret += StringFormat::Fmt(", file: %s", file->refString().c_str());
+    ret += StringFormat::Fmt(", file: %s", file->refString(dxcStyleFormatting).c_str());
   if(line)
     ret += StringFormat::Fmt(", line: %llu", line);
   if(column)
@@ -597,7 +600,7 @@ rdcstr DILexicalBlock::toString() const
   return ret;
 }
 
-rdcstr DISubrange::toString() const
+rdcstr DISubrange::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = "!DISubrange(";
   ret += StringFormat::Fmt("count: %lld", count);
@@ -607,33 +610,33 @@ rdcstr DISubrange::toString() const
   return ret;
 }
 
-rdcstr DINamespace::toString() const
+rdcstr DINamespace::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = "!DINamespace(";
   if(name)
     ret += StringFormat::Fmt("name: %s, ", escapeString(*name).c_str());
   if(scope)
-    ret += StringFormat::Fmt("scope: %s", scope->refString().c_str());
+    ret += StringFormat::Fmt("scope: %s", scope->refString(dxcStyleFormatting).c_str());
   else
     ret += "scope: null";
   if(file)
-    ret += StringFormat::Fmt(", file: %s", file->refString().c_str());
+    ret += StringFormat::Fmt(", file: %s", file->refString(dxcStyleFormatting).c_str());
   ret += StringFormat::Fmt(", line: %llu", line);
   ret += ")";
   return ret;
 }
 
-rdcstr DIImportedEntity::toString() const
+rdcstr DIImportedEntity::toString(bool dxcStyleFormatting) const
 {
   rdcstr ret = StringFormat::Fmt("!DIImportedEntity(tag: %s", ToStr(tag).c_str());
   if(name)
     ret += StringFormat::Fmt(", name: %s, ", escapeString(*name).c_str());
   if(scope)
-    ret += StringFormat::Fmt(", scope: %s", scope->refString().c_str());
+    ret += StringFormat::Fmt(", scope: %s", scope->refString(dxcStyleFormatting).c_str());
   else
     ret += ", scope: null";
   if(entity)
-    ret += StringFormat::Fmt(", entity: %s", entity->refString().c_str());
+    ret += StringFormat::Fmt(", entity: %s", entity->refString(dxcStyleFormatting).c_str());
   if(line)
     ret += StringFormat::Fmt(", line: %llu", line);
   ret += ")";

--- a/renderdoc/driver/shaders/dxil/dxil_debuginfo.h
+++ b/renderdoc/driver/shaders/dxil/dxil_debuginfo.h
@@ -363,7 +363,7 @@ struct DIFile : public DIBase
   const Metadata *file;
   const Metadata *dir;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DICompileUnit : public DIBase
@@ -404,7 +404,7 @@ struct DICompileUnit : public DIBase
   const Metadata *globals;
   const Metadata *imports;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DIBasicType : public DIBase
@@ -427,7 +427,7 @@ struct DIBasicType : public DIBase
   uint64_t alignInBits;
   DW_ENCODING encoding;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DIDerivedType : public DIBase
@@ -463,7 +463,7 @@ struct DIDerivedType : public DIBase
   DIFlags flags;
   const Metadata *extra;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DICompositeType : public DIBase
@@ -502,7 +502,7 @@ struct DICompositeType : public DIBase
   const Metadata *elements;
   const Metadata *templateParams;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DIEnum : public DIBase
@@ -512,7 +512,7 @@ struct DIEnum : public DIBase
   int64_t value;
   const rdcstr *name;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DITemplateTypeParameter : public DIBase
@@ -525,7 +525,7 @@ struct DITemplateTypeParameter : public DIBase
   const rdcstr *name;
   const Metadata *type;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DITemplateValueParameter : public DIBase
@@ -541,7 +541,7 @@ struct DITemplateValueParameter : public DIBase
   const Metadata *type;
   const Metadata *value;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DISubprogram : public DIBase
@@ -600,7 +600,7 @@ struct DISubprogram : public DIBase
       function->id = ID;
   }
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DISubroutineType : public DIBase
@@ -609,7 +609,7 @@ struct DISubroutineType : public DIBase
   DISubroutineType(const Metadata *types) : DIBase(DIType), types(types) {}
   const Metadata *types;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DIGlobalVariable : public DIBase
@@ -643,7 +643,7 @@ struct DIGlobalVariable : public DIBase
   const Metadata *variable;
   const Metadata *declaration;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DILocalVariable : public DIBase
@@ -673,7 +673,7 @@ struct DILocalVariable : public DIBase
   DIFlags flags;
   uint64_t alignInBits;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DIExpression : public DIBase
@@ -691,7 +691,7 @@ struct DIExpression : public DIBase
     } bit_piece;
   } evaluated;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DILexicalBlock : public DIBase
@@ -707,7 +707,7 @@ struct DILexicalBlock : public DIBase
   uint64_t line;
   uint64_t column;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DISubrange : public DIBase
@@ -721,7 +721,7 @@ struct DISubrange : public DIBase
   int64_t count;
   int64_t lowerBound;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DINamespace : public DIBase
@@ -737,7 +737,7 @@ struct DINamespace : public DIBase
   const rdcstr *name;
   uint64_t line;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 
 struct DIImportedEntity : public DIBase
@@ -755,7 +755,7 @@ struct DIImportedEntity : public DIBase
   uint64_t line;
   const rdcstr *name;
 
-  virtual rdcstr toString() const;
+  virtual rdcstr toString(bool dxcStyleFormatting) const;
 };
 };    // namespace DXIL
 

--- a/renderdoc/driver/shaders/dxil/dxil_reflect.cpp
+++ b/renderdoc/driver/shaders/dxil/dxil_reflect.cpp
@@ -1470,6 +1470,7 @@ rdcarray<ShaderEntryPoint> Program::GetEntryPoints()
 
 DXBC::Reflection *Program::GetReflection()
 {
+  const bool dxcStyleFormatting = m_DXCStyle;
   using namespace DXBC;
 
   Reflection *refl = new Reflection;
@@ -1489,10 +1490,10 @@ DXBC::Reflection *Program::GetReflection()
 
   if(dx.valver && dx.valver->children.size() == 1 && dx.valver->children[0]->children.size() == 2)
   {
-    m_CompilerSig +=
-        StringFormat::Fmt(" (Validation version %s.%s)",
-                          dx.valver->children[0]->children[0]->value->toString().c_str(),
-                          dx.valver->children[0]->children[1]->value->toString().c_str());
+    m_CompilerSig += StringFormat::Fmt(
+        " (Validation version %s.%s)",
+        dx.valver->children[0]->children[0]->value->toString(dxcStyleFormatting).c_str(),
+        dx.valver->children[0]->children[1]->value->toString(dxcStyleFormatting).c_str());
   }
 
   if(dx.entryPoints && dx.entryPoints->children.size() > 0 &&
@@ -1509,10 +1510,10 @@ DXBC::Reflection *Program::GetReflection()
   if(dx.shaderModel && dx.shaderModel->children.size() == 1 &&
      dx.shaderModel->children[0]->children.size() == 3)
   {
-    m_Profile =
-        StringFormat::Fmt("%s_%s_%s", dx.shaderModel->children[0]->children[0]->str.c_str(),
-                          dx.shaderModel->children[0]->children[1]->value->toString().c_str(),
-                          dx.shaderModel->children[0]->children[2]->value->toString().c_str());
+    m_Profile = StringFormat::Fmt(
+        "%s_%s_%s", dx.shaderModel->children[0]->children[0]->str.c_str(),
+        dx.shaderModel->children[0]->children[1]->value->toString(dxcStyleFormatting).c_str(),
+        dx.shaderModel->children[0]->children[2]->value->toString(dxcStyleFormatting).c_str());
   }
   else
   {


### PR DESCRIPTION
Pass in bool dxcStyleFormatting parameter to helper functions Derive dxilIdentifier from dxcStyleFormatting i.e. '%' or '_' DXIL Debugger and RD Disassembly specific helper methods choose to use "dxcStyleFormatting = false"

